### PR TITLE
Re-use SQLALchemy engine after first connection

### DIFF
--- a/src/dataio/clients/postgres_client.py
+++ b/src/dataio/clients/postgres_client.py
@@ -22,6 +22,7 @@ class PostgresClient(base_client.QueryClient):
     """
 
     conn: Optional[Connection]
+    engine = None
     execution_options: dict
     connect_args: dict
 
@@ -50,10 +51,13 @@ class PostgresClient(base_client.QueryClient):
             port=self.url.port,
             database=self.url.path,
         )
-        engine = create_engine(
-            parsed_url, execution_options=self.execution_options, connect_args=self.connect_args
-        )
-        return engine.connect()
+        if self.engine is None:
+            self.engine = create_engine(
+                parsed_url,
+                execution_options=self.execution_options,
+                connect_args=self.connect_args
+            )
+        return self.engine.connect()
 
     # Schema methods:
 


### PR DESCRIPTION
See https://trello.com/c/582bImBP/550-fix-postgres-connection-issues
See https://docs.sqlalchemy.org/en/latest/core/connections.html

The original issue involved exhaustion of the Postgres connection pool from an Airflow task. I am yet to confirm that this approach fixes the problem, but I have been able to demonstrate considerable performance implications on smaller tasks.

## Creating engine on first connection
While it's tempting to create `self.engine` inside `__init__`, this breaks passing the client to forked processes as the engine object is not pickle-able. Thus, the proposed implementation allows each forked process to create its own engine on first use.

## Performance:
Test script: https://github.com/octoenergy/data-scratch/blob/master/notebooks/io/test-client.ipynb

Querying half-hourly data for 100 MPANs:

|n_jobs| current implementation | re-using engine|
|---|---|---|
|1|87s|34s|
|8|14s|9s|