### PR TITLE
Isolate POSTGRES_UNIT_URL assertion where used

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,9 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 """
 import os
 
-import pytest
 from dataio import clients
+
+import pytest
 
 # Database fixtures:
 
@@ -14,14 +15,11 @@ from dataio import clients
 POSTGRES_TEST_URL = os.getenv("POSTGRES_TEST_URL")
 
 
-assert POSTGRES_TEST_URL is not None, "Missing test config in environment variables"
-
-
 @pytest.fixture(scope="session")
 def db_client():
     """
     Create and tear down the session-wide SQLAlchemy Db connection
     """
-    assert POSTGRES_TEST_URL is not None
+    assert POSTGRES_TEST_URL is not None, "Missing test config in environment variables"
     with clients.PostgresClient(POSTGRES_TEST_URL) as client:
         yield client


### PR DESCRIPTION
Prior to this change make unit would fail due to a missing env variable

This change isolates the assertion so no need of special context is
needed to run make unit
