### PR TITLE
Make stream clients byte/string agnostic

### DIFF
--- a/src/dataio/api.py
+++ b/src/dataio/api.py
@@ -5,11 +5,13 @@ from dataio import protocols, urls
 __all__ = ["open_reader", "open_writer"]
 
 
-def open_reader(url: str, **kwargs) -> ContextManager[protocols.Reader]:
+def open_reader(url: str, mode: str = None, **kwargs) -> ContextManager[protocols.Reader]:
     """Opens the url and returns a reader """
-    return urls.URL(url).open_reader(extras=kwargs)
+    mode = mode or ""
+    return urls.URL(url).open_reader(mode, extras=kwargs)
 
 
-def open_writer(url: str, **kwargs) -> ContextManager[protocols.Writer]:
+def open_writer(url: str, mode: str = None, **kwargs) -> ContextManager[protocols.Writer]:
     """Opens the url and returns a writer"""
-    return urls.URL(url).open_writer(extras=kwargs)
+    mode = mode or ""
+    return urls.URL(url).open_writer(mode, extras=kwargs)

--- a/src/dataio/clients/base_client.py
+++ b/src/dataio/clients/base_client.py
@@ -58,20 +58,3 @@ class QueryClient(BaseClient):
     def query(self, sql_query: str, **params) -> Iterable:
         ...
 
-
-class StreamClient(BaseClient):
-    """
-    Interface for stream-based connections
-    """
-
-    def __enter__(self) -> "StreamClient":
-        self.conn = self.connect()
-        return self
-
-    @abc.abstractmethod
-    def get(self, **params) -> protocols.ReaderClosable:
-        ...
-
-    @abc.abstractmethod
-    def put(self, file_obj: protocols.Reader, **params) -> None:
-        ...

--- a/src/dataio/clients/s3_client.py
+++ b/src/dataio/clients/s3_client.py
@@ -1,4 +1,3 @@
-import io
 from typing import Optional, Tuple, Union, cast
 
 import boto3
@@ -65,16 +64,13 @@ class S3Client(stream_client.StreamClient):
     # Stream methods:
 
     @decorators.check_conn()
-    def get(self, bucket_name: str = None, key_name: str = None) -> protocols.ReaderClosable:
+    def get(self, writer: protocols.Writer, bucket_name: str = None, key_name: str = None) -> None:
         s3_bucket, s3_key = self._fetch_bucket_and_key(bucket_name, key_name)
 
         if not self._isfile(s3_bucket, s3_key):
             raise exceptions.S3Error("Unable to fetch the remote file")
 
-        f = io.BytesIO()
-        self.conn.download_fileobj(s3_bucket, s3_key, f)  # type: ignore
-        f.seek(0)
-        return f
+        self.conn.download_fileobj(s3_bucket, s3_key, writer)  # type: ignore
 
     @decorators.check_conn()
     def put(

--- a/src/dataio/handlers/file_handler.py
+++ b/src/dataio/handlers/file_handler.py
@@ -6,9 +6,8 @@ from dataio.urls import URL
 logger = logging.getLogger(__name__)
 
 
-def _get_mode_extras(extras: dict) -> str:
-    mode = extras.get("mode", "")
-    if "b" in str(mode):
+def _get_mode_extras(mode: str) -> str:
+    if "b" in mode:
         return "b"
     return ""
 
@@ -16,7 +15,7 @@ def _get_mode_extras(extras: dict) -> str:
 class LocalFileHandler:
     """Handler for opening writers and readers for S3 buckets."""
 
-    def open_reader_for(self, url: URL, extras: dict) -> ReaderClosable:
+    def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
         """Open a local file for reading.
         If the extras argument contains a 'mode' key, it will be used to modify the opening
         mode of the local file. At the moment only 't' or 'b' are checked for the text or
@@ -24,11 +23,11 @@ class LocalFileHandler:
 
         :extras: dictionary with extra arguments for opening the file.
         """
-        mode = "r" + _get_mode_extras(extras)
+        mode = "r" + _get_mode_extras(mode)
         logger.debug(f"opening {url.path} with mode {mode}")
         return open(url.path, mode)
 
-    def open_writer_for(self, url: URL, extras: dict) -> WriterClosable:
+    def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
         """Open an s3 bucket for writing.
         If the extras argument contains a 'mode' key, it will be used to modify the opening
         mode of the local file. At the moment only 't' or 'b' are checked for the text or
@@ -36,6 +35,6 @@ class LocalFileHandler:
 
         :extras: dictionary with extra arguments for opening the file.
         """
-        mode = "w" + _get_mode_extras(extras)
+        mode = "w" + _get_mode_extras(mode)
         logger.debug(f"opening {url.path} with mode {mode}")
         return open(url.path, mode)

--- a/src/dataio/handlers/postgres_handler.py
+++ b/src/dataio/handlers/postgres_handler.py
@@ -17,11 +17,11 @@ def _get_table(url: URL) -> str:
 class PostgresURLHandler:
     """Handler for opening writers and readers ."""
 
-    def open_reader_for(self, url: URL, extras: dict) -> ReaderClosable:
+    def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
         """Not implemented."""
         raise NotImplementedError("Reading csv from postgres not implemented")
 
-    def open_writer_for(self, url: URL, extras: dict) -> WriterClosable:
+    def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
         """Open writer to dump the csv into a table in database.
 
            This stream writer only works for csv data at the moment. The url must contain

--- a/src/dataio/handlers/stream_handler.py
+++ b/src/dataio/handlers/stream_handler.py
@@ -1,10 +1,26 @@
-from typing import Callable
+import io
+from typing import Any, Callable
 
 from dataio.clients import StreamClient, StreamClientReader, StreamClientWriter
 from dataio.protocols import ReaderClosable, WriterClosable
 from dataio.urls import URL
 
 StreamClientFactory = Callable[..., StreamClient]
+
+
+def _is_bytes_mode(mode: str) -> bool:
+    if "b" in str(mode):
+        return True
+    return False
+
+
+def _get_buff_factory(mode: str):
+    buffer_factory: Any
+    if _is_bytes_mode(mode):
+        buffer_factory = io.BytesIO
+    else:
+        buffer_factory = io.StringIO
+    return buffer_factory
 
 
 class StreamURLHandler:
@@ -15,10 +31,17 @@ class StreamURLHandler:
     def __init__(self, client_factory: StreamClientFactory):
         self.client_factory = client_factory
 
-    def open_reader_for(self, url: URL, extras: dict) -> ReaderClosable:
+    def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
         """Open an stream client for reading."""
-        return StreamClientReader(self.client_factory(url, **extras))
+        buffer_factory = _get_buff_factory(mode)
+        print("reader buffer_factory", buffer_factory)
+        return StreamClientReader(
+            self.client_factory(url, **extras), buffer_factory=buffer_factory
+        )
 
-    def open_writer_for(self, url: URL, extras: dict) -> WriterClosable:
+    def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
         """Open an stream client writing."""
-        return StreamClientWriter(self.client_factory(url, **extras))
+        buffer_factory = _get_buff_factory(mode)
+        return StreamClientWriter(
+            self.client_factory(url, **extras), buffer_factory=buffer_factory
+        )

--- a/src/dataio/urls.py
+++ b/src/dataio/urls.py
@@ -17,10 +17,10 @@ class URLError(Exception):
 
 
 class URLHandler(Protocol):
-    def open_reader_for(self, url: "URL", extras: dict) -> protocols.ReaderClosable:
+    def open_reader_for(self, url: "URL", mode: str, extras: dict) -> protocols.ReaderClosable:
         ...
 
-    def open_writer_for(self, url: "URL", extras: dict) -> protocols.WriterClosable:
+    def open_writer_for(self, url: "URL", mode: str, extras: dict) -> protocols.WriterClosable:
         ...
 
 
@@ -202,18 +202,26 @@ class URL:
     def url(self) -> str:
         return self._url
 
-    def open_reader(self, extras: Optional[dict] = None) -> ContextManager[protocols.Reader]:
+    def open_reader(
+        self, mode: str, extras: Optional[dict] = None
+    ) -> ContextManager[protocols.Reader]:
 
         """Open a reader for the stream located at this url"""
 
         extras = extras or {}
-        reader = self._handler_registry.get_handler(self._scheme).open_reader_for(self, extras)
+        reader = self._handler_registry.get_handler(self._scheme).open_reader_for(
+            self, mode, extras
+        )
         return _ReaderContextManager(reader)
 
-    def open_writer(self, extras: Optional[dict] = None) -> ContextManager[protocols.Writer]:
+    def open_writer(
+        self, mode: str, extras: Optional[dict] = None
+    ) -> ContextManager[protocols.Writer]:
         """Open a writer for the stream located at this url"""
         extras = extras or {}
-        writer = self._handler_registry.get_handler(self._scheme).open_writer_for(self, extras)
+        writer = self._handler_registry.get_handler(self._scheme).open_writer_for(
+            self, mode, extras
+        )
         return _WriterContextManager(writer)
 
     @classmethod

--- a/tests/integration/clients/test_s3.py
+++ b/tests/integration/clients/test_s3.py
@@ -25,7 +25,7 @@ class TestS3Client:
             client.conn.create_bucket(Bucket=bucket or client.url.hostname)
 
             with pytest.raises(exceptions.S3Error):
-                client.get(bucket_name=bucket, key_name=key)
+                client.get(io.StringIO(), bucket_name=bucket, key_name=key)
 
     @pytest.mark.parametrize(
         "url,bucket,key",
@@ -41,8 +41,9 @@ class TestS3Client:
             client.conn.put_object(
                 Bucket=bucket or client.bucket, Key=key or client.key_name, Body=stream
             )
-
-            buffer = client.get(bucket_name=bucket, key_name=key)
+            buffer = io.BytesIO()
+            client.get(buffer, bucket_name=bucket, key_name=key)
+            buffer.seek(0)
 
             assert buffer.getvalue().decode() == stream
 

--- a/tests/unit/clients/test_ftp.py
+++ b/tests/unit/clients/test_ftp.py
@@ -1,4 +1,5 @@
 import pytest
+import io
 from dataio.clients import exceptions, ftp_client
 
 
@@ -50,7 +51,7 @@ class TestFTPClient:
         with ftp_client.FTPClient(url) as client:
 
             with pytest.raises(exceptions.FTPError):
-                client.get(file_path=path)
+                client.get(io.StringIO(), file_path=path)
 
 
 class TestSFTPClient:
@@ -66,4 +67,4 @@ class TestSFTPClient:
         with ftp_client.SFTPClient(url) as client:
 
             with pytest.raises(exceptions.FTPError):
-                client.get(file_path=path)
+                client.get(io.StringIO(), file_path=path)

--- a/tests/unit/clients/test_s3.py
+++ b/tests/unit/clients/test_s3.py
@@ -2,6 +2,7 @@ from dataio.clients import exceptions, s3_client
 
 import moto
 import pytest
+import io
 
 
 @pytest.fixture()
@@ -44,6 +45,5 @@ class TestS3Client:
     )
     def test_get_invalid_path(self, url, bucket, key, mocked_conn):
         with s3_client.S3Client(url) as client:
-
             with pytest.raises(exceptions.S3Error):
-                client.get(bucket_name=bucket, key_name=key)
+                client.get(io.StringIO(), bucket_name=bucket, key_name=key)

--- a/tests/unit/clients/test_stream_client.py
+++ b/tests/unit/clients/test_stream_client.py
@@ -27,16 +27,16 @@ class TestStreamClientReader:
     def test_read(self, mocker):
         client = mocker.MagicMock()
         expected = bytes("hello world", "utf-8")
-        client.get.return_value = io.BytesIO(expected)
+        client.get = lambda f: f.write(expected)
 
-        reader = clients.StreamClientReader(client)
+        reader = clients.StreamClientReader(client, io.BytesIO)
         contents = reader.read()
         assert expected == contents
 
     def test_close(self, mocker):
         client = mocker.MagicMock()
 
-        reader = clients.StreamClientReader(client)
+        reader = clients.StreamClientReader(client, io.BytesIO)
         reader.close()
 
         assert reader.buffer.closed

--- a/tests/unit/handlers/test_s3_handler.py
+++ b/tests/unit/handlers/test_s3_handler.py
@@ -29,10 +29,10 @@ def test_open_s3_url_writing(fixture_conn):
     conn.create_bucket(Bucket="my_bucket")
 
     expected = bytes("hello from url", "utf-8")
-    with open_writer("s3://public_key:private_key@my_bucket/my_file") as writer:
+    with open_writer("s3://public_key:private_key@my_bucket/my_file", mode="b") as writer:
         writer.write(expected)
 
-    with open_reader("s3://public_key:private_key@my_bucket/my_file") as reader:
+    with open_reader("s3://public_key:private_key@my_bucket/my_file", mode="b") as reader:
         contents = reader.read()
 
     assert contents == expected

--- a/tests/unit/handlers/test_stream_handler.py
+++ b/tests/unit/handlers/test_stream_handler.py
@@ -1,14 +1,15 @@
 import io
 
-from dataio import URL, Reader
+from dataio import URL, Reader, Writer
+from dataio.clients import StreamClient
 from dataio.handlers.stream_handler import StreamURLHandler
-
-from dataio.clients.base_client import StreamClient
 
 
 class FakeClient(StreamClient):
-    def __init__(self, url: URL, **kwargs):
-        self._writer: io.BytesIO = io.BytesIO()
+    def __init__(self, url: URL, message=None, buffer_factory=None):
+        factory = buffer_factory or io.StringIO
+        self._writer = factory()
+        self._message = message or "hello"
 
     def connect(self):
         pass
@@ -16,29 +17,51 @@ class FakeClient(StreamClient):
     def __enter__(self):
         pass
 
-    def get(self) -> io.StringIO:
-        return io.StringIO("hello")
+    def get(self, writer: Writer) -> None:
+        writer.write(self._message)
 
     def put(self, reader: Reader, **params) -> None:
         self._writer.write(reader.read())
         self._writer.seek(0)
 
 
-def test_open_reader_for(register_handler):
+def test_open_reader_for_string(register_handler):
     handler = StreamURLHandler(FakeClient)
-
-    reader = handler.open_reader_for(URL("registered://my/path"), extras={})
-
+    reader = handler.open_reader_for(URL("registered://my/path"), mode="t", extras={})
     assert "hello" == reader.read()
 
 
-def test_open_writer_for(register_handler):
+def test_open_reader_for_bytes(register_handler):
+    message = bytes("hello", "utf-8")
+    handler = StreamURLHandler(FakeClient)
+    reader = handler.open_reader_for(
+        URL("registered://my/path"),
+        mode="b",
+        extras=dict(message=message, buffer_factory=io.BytesIO),
+    )
+    assert "hello" == reader.read().decode("utf-8")
+
+
+def test_open_writer_for_string(register_handler):
     url = URL("registered://my/path")
     client = FakeClient(url)
     handler = StreamURLHandler(lambda url, **kwargs: client)
-    writer = handler.open_writer_for(url, extras={})
+    writer = handler.open_writer_for(url, mode="t", extras={})
 
-    writer.write(bytes("test", "utf-8"))
+    writer.write("test")
     writer.close()
 
-    assert client._writer.getvalue().decode("utf-8") == "test"
+    assert client._writer.getvalue() == "test"
+
+
+def test_open_writer_for_bytes(register_handler):
+    url = URL("registered://my/path")
+    client = FakeClient(url, buffer_factory=io.BytesIO)
+    handler = StreamURLHandler(lambda url, **kwargs: client)
+    writer = handler.open_writer_for(url, mode="b", extras=dict())
+
+    message = bytes("hello", "utf-8")
+    writer.write(message)
+    writer.close()
+
+    assert client._writer.getvalue() == message


### PR DESCRIPTION
Prior to this change clients were aware of the actual encoding used.
This info belongs to the client code (i.e. writing a csv vs a pickle)
not the client itself.

This change leaves the decision the code opening the stream not
hardcoding the instantion of the buffers in the clients