### PR TITLE
Have bytearray to be our canonical format

### DIFF
--- a/src/dataio/handlers/s3_handler.py
+++ b/src/dataio/handlers/s3_handler.py
@@ -1,73 +1,12 @@
-""" S3 objects as  streams
+from dataio.clients import s3_client
 
-General note. S3 only supports streams as binary data, which is not fully pythonic
-(albeit problably more sane).
-
-In order to offer client code write csv/parquet files into s3
-buckets without having to worry about the underlying implementations
-s3 handlers modifies the StreamClientReader/Writers.
-It hides which stream flavour (string, bytes) is
-used and only exposes bytes versions to the S3Client.
-
-This is down by using TextIOWrapper when text is needed by the client code and exposes
-the inner buffer to the S3 client.
-"""
-
-import io
-
-from dataio.clients import (StreamClient, StreamClientReader,
-                            StreamClientWriter, s3_client)
-from dataio.protocols import ReaderClosable, WriterClosable
-from dataio.urls import URL
-
-from .stream_handler import is_bytes_mode
+from .stream_handler import StreamURLHandler
 
 __all__ = ["S3URLHandler"]
 
 
-class S3ClientReader(StreamClientReader):
-    inner_buffer: io.BytesIO
-
-    def __init__(self, client: StreamClient):
-        self.inner_buffer = io.BytesIO()
-        super().__init__(client, io.TextIOWrapper(self.inner_buffer, encoding="utf-8"))
-
-    def _load(self):
-        # interacts with the client in terms of bytes
-        with self.client:
-            self.client.get(self.inner_buffer)
-        self.buffer.seek(0)
-
-
-class S3ClientWriter(StreamClientWriter):
-    inner_buffer: io.BytesIO
-
-    def __init__(self, client: StreamClient):
-        self.inner_buffer = io.BytesIO()
-        super().__init__(client, io.TextIOWrapper(self.inner_buffer, encoding="utf-8"))
-
-    def _flush(self) -> None:
-        """Flush and close the writer."""
-        self.buffer.seek(0)
-        # interacts with the client in terms of bytes
-        with self.client:
-            self.client.put(self.inner_buffer)
-
-
-class S3URLHandler:
+class S3URLHandler(StreamURLHandler):
     """Handler for opening writers and readers for S3 buckets."""
 
-    def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
-        """Open an stream client for reading."""
-        client = s3_client.S3Client(url, **extras)
-        if not is_bytes_mode(mode):
-            return S3ClientReader(client)
-
-        return StreamClientReader(client, io.BytesIO())
-
-    def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
-        """Open an stream client writing."""
-        client = s3_client.S3Client(url, **extras)
-        if not is_bytes_mode(mode):
-            return S3ClientWriter(client)
-        return StreamClientWriter(client, io.BytesIO())
+    def __init__(self):
+        super().__init__(s3_client.S3Client)

--- a/src/dataio/handlers/stream_handler.py
+++ b/src/dataio/handlers/stream_handler.py
@@ -1,25 +1,19 @@
 import io
-from typing import Any, Callable
+from typing import Callable
 
-from dataio.clients import StreamClient, StreamClientReader, StreamClientWriter
+from dataio.clients import (StreamClient, StreamClientReader,
+                            StreamClientWriter, StringToBytesClientReader,
+                            StringToBytesClientWriter)
 from dataio.protocols import ReaderClosable, WriterClosable
 from dataio.urls import URL
 
 StreamClientFactory = Callable[..., StreamClient]
 
 
-def is_bytes_mode(mode: str) -> bool:
+def _is_bytes_mode(mode: str) -> bool:
     if "b" in str(mode):
         return True
     return False
-
-
-def _get_buff(mode: str):
-    buffer_factory: Any
-    if is_bytes_mode(mode):
-        return io.BytesIO()
-    else:
-        return io.StringIO()
 
 
 class StreamURLHandler:
@@ -32,14 +26,16 @@ class StreamURLHandler:
 
     def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
         """Open an stream client for reading."""
-        buffer = _get_buff(mode)
-        return StreamClientReader(
-            self.client_factory(url, **extras), buffer
-        )
+        client = self.client_factory(url, **extras)
+
+        if _is_bytes_mode(mode):
+            return StreamClientReader(client, io.BytesIO())
+        return StringToBytesClientReader(client)
 
     def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
         """Open an stream client writing."""
-        buffer = _get_buff(mode)
-        return StreamClientWriter(
-            self.client_factory(url, **extras), buffer
-        )
+        client = self.client_factory(url, **extras)
+
+        if _is_bytes_mode(mode):
+            return StreamClientWriter(client, io.BytesIO())
+        return StringToBytesClientWriter(client)

--- a/tests/unit/handlers/test_http_handler.py
+++ b/tests/unit/handlers/test_http_handler.py
@@ -15,18 +15,21 @@ def test_handler_is_registered(url, scheme):
 
 
 @pytest.mark.parametrize(
-    "mode,content", [("b", bytes(TEST_PAYLOAD, "utf-8")), ("s", TEST_PAYLOAD)]
+    "mode,content, expected_content", [
+        ("b", bytes(TEST_PAYLOAD, "utf-8"), bytes(TEST_PAYLOAD, "utf-8")),
+        ("s", bytes(TEST_PAYLOAD, "utf-8"), TEST_PAYLOAD)
+    ]
 )
-def test_open_http_url_reading(mode, content, mocker):
+def test_open_http_url_reading(mode, content, expected_content, mocker):
     mocked_response = mocker.Mock(content=content)
     mocked_session_call = mocker.patch.object(
         requests.Session, "send", return_value=mocked_response
     )
 
     with api.open_reader("http://host.com/request", mode) as reader:
-        content = reader.read()
+        read_content = reader.read()
 
-    assert content == content
+    assert read_content == expected_content
     mocked_session_call.assert_called_once()
 
 

--- a/tests/unit/handlers/test_stream_handler.py
+++ b/tests/unit/handlers/test_stream_handler.py
@@ -6,10 +6,10 @@ from dataio.handlers.stream_handler import StreamURLHandler
 
 
 class FakeClient(StreamClient):
-    def __init__(self, url: URL, message=None, buffer_factory=None):
-        factory = buffer_factory or io.StringIO
-        self._writer = factory()
-        self._message = message or "hello"
+    # clients only understand bytes
+    def __init__(self, url: URL, message: bytearray = None):
+        self._writer = io.BytesIO()
+        self._message = message or bytes("hello", encoding="utf-8")
 
     def connect(self):
         pass
@@ -37,9 +37,9 @@ def test_open_reader_for_bytes(register_handler):
     reader = handler.open_reader_for(
         URL("registered://my/path"),
         mode="b",
-        extras=dict(message=message, buffer_factory=io.BytesIO),
+        extras={},
     )
-    assert "hello" == reader.read().decode("utf-8")
+    assert message == reader.read()
 
 
 def test_open_writer_for_string(register_handler):
@@ -51,12 +51,12 @@ def test_open_writer_for_string(register_handler):
     writer.write("test")
     writer.close()
 
-    assert client._writer.getvalue() == "test"
+    assert client._writer.getvalue().decode("utf-8") == "test"
 
 
 def test_open_writer_for_bytes(register_handler):
     url = URL("registered://my/path")
-    client = FakeClient(url, buffer_factory=io.BytesIO)
+    client = FakeClient(url)
     handler = StreamURLHandler(lambda url, **kwargs: client)
     writer = handler.open_writer_for(url, mode="b", extras=dict())
 


### PR DESCRIPTION
Prior to this change there was an issue in terms of giving support to
different clients in both string and bytearray, but we have decided to
move towards a pure binary approach. So all the clients (S3, ftp...).

This change wraps the stream readers and writers in a way that they hide
string streams from the clients, so someone opening `open(url, "wt")`
will be able to write stings but the client will receive bytes.