### PR TITLE
Remove error raised when an empty DataFrame is returned.

### DIFF
--- a/src/dataio/clients/sqla_client.py
+++ b/src/dataio/clients/sqla_client.py
@@ -8,7 +8,7 @@ from sqlalchemy.engine import url as sqla_url
 from sqlalchemy.orm import session, sessionmaker
 from sqlalchemy.sql.schema import MetaData
 
-from . import base_client, decorators, exceptions
+from . import base_client, decorators
 
 __all__ = ["SQLAlchemyClient", "bound_session", "atomic_session"]
 
@@ -114,8 +114,6 @@ class SQLAlchemyClient(base_client.QueryClient):
         Run a raw SQL query and return a data frame
         """
         df = pd.read_sql(sql_query, self.conn, params=params, **kwargs)
-        if df.empty:
-            raise exceptions.SQLAlchemyError("Empty Pandas dataframe content")
         return df
 
 


### PR DESCRIPTION
Just like an empty query result, an empty dataframe indicates that 0 rows were found matching the query, and should be considered a valid return as it can be e.g. appended to other DataFrames.