### PR TITLE
Assert mode at the api level

### DIFF
--- a/tests/unit/handlers/test_athena_handler.py
+++ b/tests/unit/handlers/test_athena_handler.py
@@ -1,7 +1,6 @@
 import pytest
 
-from dataio import URL
-from dataio.api import _open_reader, _open_writer
+from dataio import URL, api
 
 
 athena_url = (
@@ -14,10 +13,9 @@ def test_athena_scheme():
     assert url.scheme == "awsathena+rest"
 
 
-@pytest.mark.parametrize("mode", ["r", "w"])
-def test_handler_raises_error(mode):
+def test_handler_raises_error():
     with pytest.raises(NotImplementedError):
-        _open_reader(athena_url)
+        api.open(athena_url)
 
     with pytest.raises(NotImplementedError):
-        _open_writer(athena_url)
+        api.open(athena_url, mode="w")

--- a/tests/unit/handlers/test_file_handler.py
+++ b/tests/unit/handlers/test_file_handler.py
@@ -29,22 +29,14 @@ def test_file_scheme():
 
 
 @pytest.mark.parametrize(
-    ["extras", "expected"],
-    [
-        ({}, "hello file"),
-        ({"mode": "t"}, "hello file"),
-        ({"mode": "rt"}, "hello file"),
-        ({"mode": "wt"}, "hello file"),
-        ({"mode": "b"}, bytes("hello file", "utf-8")),
-        ({"mode": "wb"}, bytes("hello file", "utf-8")),
-        ({"mode": "rb"}, bytes("hello file", "utf-8")),
-    ],
+    ["mode", "expected"],
+    [("", "hello file"), ("t", "hello file"), ("b", bytes("hello file", "utf-8"))],
 )
-def test_file_read_write(extras, expected, temp_filename):
-    with api._open_writer(temp_filename, **extras) as writer:
+def test_file_read_write(mode, expected, temp_filename):
+    with api.open(temp_filename, mode="w" + mode) as writer:
         contents = writer.write(expected)
 
-    with api._open_reader(temp_filename, **extras) as reader:
+    with api.open(temp_filename, mode=mode) as reader:
         contents = reader.read()
 
     assert contents == expected

--- a/tests/unit/handlers/test_http_handler.py
+++ b/tests/unit/handlers/test_http_handler.py
@@ -17,7 +17,7 @@ def test_handler_is_registered(url, scheme):
 @pytest.mark.parametrize(
     "mode,content, expected_content", [
         ("b", bytes(TEST_PAYLOAD, "utf-8"), bytes(TEST_PAYLOAD, "utf-8")),
-        ("s", bytes(TEST_PAYLOAD, "utf-8"), TEST_PAYLOAD)
+        ("t", bytes(TEST_PAYLOAD, "utf-8"), TEST_PAYLOAD)
     ]
 )
 def test_open_http_url_reading(mode, content, expected_content, mocker):
@@ -26,7 +26,7 @@ def test_open_http_url_reading(mode, content, expected_content, mocker):
         requests.Session, "send", return_value=mocked_response
     )
 
-    with api._open_reader("http://host.com/request", mode) as reader:
+    with api.open("http://host.com/request", mode=mode) as reader:
         read_content = reader.read()
 
     assert read_content == expected_content
@@ -34,9 +34,9 @@ def test_open_http_url_reading(mode, content, expected_content, mocker):
 
 
 @pytest.mark.parametrize(
-    "mode,content", [("b", bytes(TEST_PAYLOAD, "utf-8")), ("s", TEST_PAYLOAD)]
+    "mode,content", [("wb", bytes(TEST_PAYLOAD, "utf-8")), ("wt", TEST_PAYLOAD)]
 )
 def test_open_http_url_writer(mode, content):
     with pytest.raises(NotImplementedError):
-        with api._open_writer("http://host.com/request", mode) as writer:
+        with api.open("http://host.com/request", mode=mode) as writer:
             writer.write(content)

--- a/tests/unit/handlers/test_postgres_handler.py
+++ b/tests/unit/handlers/test_postgres_handler.py
@@ -1,10 +1,9 @@
 import csv
 import io
 
-
 import pytest
-from dataio import URL
-from dataio.api import _open_writer
+
+from dataio import URL, api
 
 
 @pytest.fixture
@@ -25,7 +24,7 @@ def test_dump_csv(csv_data, csv_dumper, mocker):
     recorder = csv_dumper
     mock.return_value = recorder
 
-    with _open_writer("postgresql://localhost/database::my_table") as writer:
+    with api.open("postgresql://localhost/database::my_table", mode="w") as writer:
         writer.write(csv_data.read())
 
     csv_data.seek(0)
@@ -39,7 +38,7 @@ def test_create_client_correct_url(csv_data, csv_dumper, mocker):
     recorder = csv_dumper
     mock.return_value = recorder
 
-    with _open_writer("postgresql://localhost/database::my_table") as writer:
+    with api.open("postgresql://localhost/database::my_table", mode="w") as writer:
         writer.write(csv_data.read())
 
     mock.assert_called_with(URL("postgresql://localhost/database"))
@@ -50,5 +49,5 @@ def test_dump_csv_no_table(csv_data, csv_dumper, mocker):
     recorder = csv_dumper
     mock.return_value = recorder
     with pytest.raises(ValueError):
-        with _open_writer("postgresql://localhost/database") as writer:
+        with api.open("postgresql://localhost/database", mode="w") as writer:
             writer.write(csv_data.read())

--- a/tests/unit/handlers/test_s3_handler.py
+++ b/tests/unit/handlers/test_s3_handler.py
@@ -1,10 +1,11 @@
 # from dataio.handlers import s3_handler
 import boto3
-from dataio.api import _open_reader, _open_writer
-from dataio.urls import URL
-
 import moto
 import pytest
+
+from dataio import api
+from dataio.urls import URL
+
 
 AWS_PUBLIC_KEY = "public_key"
 AWS_PRIVATE_KEY = "private_key"
@@ -29,10 +30,10 @@ def test_open_s3_url_writing(fixture_conn):
     conn.create_bucket(Bucket="my_bucket")
 
     expected = bytes("hello from url", "utf-8")
-    with _open_writer("s3://public_key:private_key@my_bucket/my_file", mode="b") as writer:
+    with api.open("s3://public_key:private_key@my_bucket/my_file", mode="wb") as writer:
         writer.write(expected)
 
-    with _open_reader("s3://public_key:private_key@my_bucket/my_file", mode="b") as reader:
+    with api.open("s3://public_key:private_key@my_bucket/my_file", mode="rb") as reader:
         contents = reader.read()
 
     assert contents == expected
@@ -45,10 +46,10 @@ def test_open_s3_url_writing_string(fixture_conn):
     conn.create_bucket(Bucket="my_bucket")
 
     expected = "hello from url"
-    with _open_writer("s3://public_key:private_key@my_bucket/my_file") as writer:
+    with api.open("s3://public_key:private_key@my_bucket/my_file", mode="w") as writer:
         writer.write(expected)
 
-    with _open_reader("s3://public_key:private_key@my_bucket/my_file") as reader:
+    with api.open("s3://public_key:private_key@my_bucket/my_file", mode="r") as reader:
         contents = reader.read()
 
     assert contents == expected

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -1,0 +1,13 @@
+import pytest
+
+from dataio.api import _assert_mode
+
+
+@pytest.mark.parametrize("mode", ["r", "w", "b", "t", "rb", "rt", "wt", "wb", ""])
+def test_allowed_modes(mode):
+    _assert_mode(mode)  # exception raised if not allowed
+
+
+def test_mode_error():
+    with pytest.raises(ValueError):
+        _assert_mode("jj")


### PR DESCRIPTION
Prior to this change the mode for opening the file was too relaxed and
was left to the handlers to check it's validity.

This change adds sanity checks for the mode at the api level