### PR TITLE
Do not raise error closing a closed client connection

### DIFF
--- a/src/dataio/clients/base_client.py
+++ b/src/dataio/clients/base_client.py
@@ -46,11 +46,9 @@ class BaseClient(Generic[T], metaclass=abc.ABCMeta):
 
     def close(self) -> None:
         """Close the client connection. """
-        if self.closed:
-            raise ValueError("Trying to close a closed client")
-
-        self.conn.close()
-        self.closed = True
+        if not self.closed:
+            self.conn.close()
+            self.closed = True
 
 
 class StreamClient(BaseClient["StreamClient"]):

--- a/tests/unit/clients/test_base_client.py
+++ b/tests/unit/clients/test_base_client.py
@@ -1,7 +1,5 @@
 import io
 
-import pytest
-
 from dataio.clients import base_client
 from dataio.urls import URL
 
@@ -51,10 +49,3 @@ class TestBaseClient:
         with FakeClient(url) as fake_client:
             fake_client.conn = mocked_conn
             assert not fake_client.closed
-
-    def test_client_error_closed_(self, mocker, register_handler):
-        url = "registered:///path"
-        fake_client = FakeClient(url)
-        # never opened
-        with pytest.raises(ValueError):
-            fake_client.close()


### PR DESCRIPTION
As is the case for builtin streams or SQLAlchemy. This allows use inside nested context managers.