### PR TITLE
Better handle slashes in paths in creds injection

### DIFF
--- a/src/dataio/credentials/injection.py
+++ b/src/dataio/credentials/injection.py
@@ -98,16 +98,26 @@ def _similarity(path_1: str, path_2: str) -> float:
 
     That means that the path of the url to inject to should be more specific than the credentials.
     """
+    path_1 = _clean_path(path_1)
+    path_2 = _clean_path(path_2)
+
     if not path_1 and not path_2:
         return 0.5  # non-zero similarity when path is empty
 
     if not path_1 or not path_2:
         return 0.5
+
     # split path elements
-    path_1_elements = re.split(PATH_DELIMITERS, path_1.lstrip("/"))
-    path_2_elements = re.split(PATH_DELIMITERS, path_2.lstrip("/"))
+
+    path_1_elements = re.split(PATH_DELIMITERS, path_1)
+    path_2_elements = re.split(PATH_DELIMITERS, path_2)
 
     return _compute_parts_similarity(path_1_elements, path_2_elements)
+
+
+def _clean_path(path: str):
+    path = path or ""
+    return path.strip("/")
 
 
 def _compute_parts_similarity(elements_1: List[str], elements_2: List[str]) -> float:

--- a/tests/unit/credentials/test_injection.py
+++ b/tests/unit/credentials/test_injection.py
@@ -52,6 +52,16 @@ from dataio.credentials import injection
             "registered://octo.energy/database?key=value_2",
             "registered://user:password@octo.energy:5544/database?key=value_2",
         ],
+        [
+            "registered://user:password@octo.energy/",  # trailing slash
+            "registered://octo.energy/file",
+            "registered://user:password@octo.energy/file",
+        ],
+        [
+            "registered://user:password@octo.energy/",  # trailing slash
+            "registered://octo.energy/path/",
+            "registered://user:password@octo.energy/path/",
+        ],
     ],
 )
 def test_simple_authenticate(with_creds, raw, expected, register_handler):


### PR DESCRIPTION
Prior to this change tailing slashes would make credentials injection not work.

This change fixes the issue by cleaning the paths before comparing them