### PR TITLE
Add a readline method to a StreamClientReader

### DIFF
--- a/src/dataio/streams/base_stream.py
+++ b/src/dataio/streams/base_stream.py
@@ -98,6 +98,11 @@ class StreamClientReader(StreamBaseIO):
         """Read the contents of the buffer."""
         return self.buffer.read(size)
 
+    def readline(self, size: int = -1):
+        """Read and return one line from the buffer."""
+        # Additional method required for unpickling Python objects
+        return self.buffer.readline(size)
+
     def close(self) -> None:
         """Close the writer."""
         self.buffer.close()

--- a/tests/functional/s3/test_fileformat.py
+++ b/tests/functional/s3/test_fileformat.py
@@ -1,0 +1,30 @@
+import pickle
+
+import pytest
+
+import dataio
+
+
+TEST_BUCKET = "dataio-bucket"
+
+
+@pytest.fixture
+def fixture_client(s3_client):
+    s3_client.conn.create_bucket(Bucket=TEST_BUCKET)
+    yield s3_client
+
+
+def test_pickle(fixture_client):
+    expected = """
+    This is a highly convoluted test,
+    with multiple output...
+    encountered.
+    """
+
+    with dataio.open(f"s3://hostname/data.pickle", mode="wb") as f:
+        pickle.dump(expected, f)
+
+    with dataio.open(f"s3://hostname/data.pickle", mode="rb") as f:
+        retrieved = pickle.load(f)
+
+    assert expected == retrieved

--- a/tests/unit/streams/test_base_stream.py
+++ b/tests/unit/streams/test_base_stream.py
@@ -33,6 +33,16 @@ class TestStreamClientReader:
         contents = reader.read()
         assert expected == contents
 
+    def test_readline(self, mocker):
+        client = mocker.MagicMock()
+        expected = bytes("hello world\n", "utf-8")
+        retrieved = expected + bytes("this is a new line", "utf-8")
+        client.get = lambda f: f.write(retrieved)
+
+        reader = base_stream.StreamClientReader(client, io.BytesIO())
+        contents = reader.readline()
+        assert expected == contents
+
     def test_close(self, mocker):
         client = mocker.MagicMock()
 


### PR DESCRIPTION
Pickling requires a read and a readline method on buffers.
Due to an asymetric behaviour for pickle methods load and dump.