### PR TITLE
Add AthenaClient to allow faster query execution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,9 @@ jobs:
       - run:
           name: Run S3 functional tests
           command: make functional-s3
+      
+      - codecov/upload:
+          file: ./coverage.xml
 
   functional-ftp:
     working_directory: ~/lib
@@ -125,6 +128,9 @@ jobs:
       - run:
           name: Run postgres functional tests
           command: make functional-ftp
+      
+      - codecov/upload:
+          file: ./coverage.xml
 
   functional-sftp:
     working_directory: ~/lib
@@ -151,6 +157,9 @@ jobs:
       - run:
           name: Run sftp functional tests
           command: make functional-sftp
+      
+      - codecov/upload:
+          file: ./coverage.xml
 
   functional-postgres:
     working_directory: ~/lib
@@ -180,6 +189,9 @@ jobs:
       - run:
           name: Run postgres functional tests
           command: make functional-postgres
+      
+      - codecov/upload:
+          file: ./coverage.xml
 
   deploy:
     working_directory: ~/lib

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ lint:
 	pipenv run mypy tests
 
 unit:
-	pipenv run pytest tests/unit --cov=./src/tentaclio/ --cov-report xml
+	pipenv run pytest tests/unit
 
 functional-s3:
 	pipenv run pytest tests/functional/s3

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,3 +28,4 @@ python_files = test_*.py
 python_classes = Test
 python_functions = test_*
 filterwarnings = error::RuntimeWarning
+addopts =  --cov=./src/tentaclio/ --cov-report xml --cov-report term

--- a/src/tentaclio/clients/__init__.py
+++ b/src/tentaclio/clients/__init__.py
@@ -10,3 +10,4 @@ from .http_client import *  # noqa
 from .postgres_client import *  # noqa
 from .s3_client import *  # noqa
 from .sqla_client import *  # noqa
+from .athena_client import *  # noqa

--- a/src/tentaclio/clients/athena_client.py
+++ b/src/tentaclio/clients/athena_client.py
@@ -23,5 +23,6 @@ class AthenaClient(sqla_client.SQLAlchemyClient):
     @decorators.check_conn
     def get_df(self, sql_query: str, params: dict = None, **kwargs) -> pd.DataFrame:
         """Run a raw SQL query and return a data frame."""
-        cursor = self.conn.connection.cursor(PandasCursor)
-        return cursor.execute(sql_query, parameters=params, **kwargs).as_pandas()
+        raw_conn = self._get_raw_conn()
+        raw_cursor = raw_conn.cursor(PandasCursor)
+        return raw_cursor.execute(sql_query, parameters=params, **kwargs).as_pandas()

--- a/src/tentaclio/clients/athena_client.py
+++ b/src/tentaclio/clients/athena_client.py
@@ -7,7 +7,6 @@ which is more performant than using sql alchemy functions.
 import pandas as pd
 from pyathena.pandas_cursor import PandasCursor
 
-
 from . import decorators, sqla_client
 
 
@@ -18,7 +17,7 @@ class AthenaClient(sqla_client.SQLAlchemyClient):
     """Postgres client, backed by a SQLAlchemy connection."""
 
     allowed_schemes = ["awsathena+rest"]
-
+    connect_args_default = dict(cursor_class=PandasCursor)
     # Athena-specific fast query result retrieval:
 
     @decorators.check_conn

--- a/src/tentaclio/clients/athena_client.py
+++ b/src/tentaclio/clients/athena_client.py
@@ -1,0 +1,28 @@
+"""AWS Athena query client.
+
+Overrides the `get_df` convenience methods for loading a DataFrame using PandasCursor,
+which is more performant than using sql alchemy functions.
+"""
+
+import pandas as pd
+from pyathena.pandas_cursor import PandasCursor
+
+
+from . import decorators, sqla_client
+
+
+__all__ = ["AthenaClient"]
+
+
+class AthenaClient(sqla_client.SQLAlchemyClient):
+    """Postgres client, backed by a SQLAlchemy connection."""
+
+    allowed_schemes = ["awsathena+rest"]
+
+    # Athena-specific fast query result retrieval:
+
+    @decorators.check_conn
+    def get_df(self, sql_query: str, params: dict = None, **kwargs) -> pd.DataFrame:
+        """Run a raw SQL query and return a data frame."""
+        cursor = self.conn.connection.cursor(PandasCursor)
+        return cursor.execute(sql_query, parameters=params, **kwargs).as_pandas()

--- a/src/tentaclio/clients/postgres_client.py
+++ b/src/tentaclio/clients/postgres_client.py
@@ -47,7 +47,7 @@ class PostgresClient(sqla_client.SQLAlchemyClient):
         sql_query = f"""COPY {dest_table} ({sql_columns}) FROM STDIN
                         WITH CSV HEADER DELIMITER AS ','
                         NULL AS 'NULL';"""
-        raw_conn = self.conn.engine.raw_connection()
+        raw_conn = self._get_raw_conn()
         try:
             raw_conn.cursor().copy_expert(sql_query, csv_reader)
         except Exception:

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -28,6 +28,8 @@ class SQLAlchemyClient(base_client.QueryClient):
 
     # The allowed drivers depend on the dependencies installed.
     allowed_schemes = ["mssql", "postgresql", "sqlite", "awsathena+rest"]
+    # Default connect_args
+    connect_args_default: dict = {}
 
     conn: Connection
     engine = None
@@ -48,7 +50,7 @@ class SQLAlchemyClient(base_client.QueryClient):
         This is a wrapper for sqlalchemy engine/connection creation.
         """
         self.execution_options = execution_options or {}
-        self.connect_args = connect_args or {}
+        self.connect_args = connect_args or self.connect_args_default
         super().__init__(url)
 
         # the database doesn't start with /

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -85,6 +85,10 @@ class SQLAlchemyClient(base_client.QueryClient):
             )
         return self.engine.connect()
 
+    def _get_raw_conn(self):
+        """Acquire raw DBAPI connection from the pool."""
+        return self.conn.engine.raw_connection()
+
     # Schema methods:
 
     def set_schema(self, meta_data: MetaData) -> None:

--- a/tests/unit/clients/test_athena_client.py
+++ b/tests/unit/clients/test_athena_client.py
@@ -1,0 +1,59 @@
+import pytest
+
+from pyathena.pandas_cursor import PandasCursor
+
+from tentaclio.clients.athena_client import AthenaClient
+
+
+class TestAthenaClient:
+    @pytest.mark.parametrize("url", ["postgresql://:@localhost", "s3://:@s3"])
+    def test_invalid_scheme(self, url):
+        with pytest.raises(ValueError):
+            AthenaClient(url)
+
+    @pytest.mark.parametrize(
+        "url, username, password, hostname, port, database, query",
+        [
+            ("awsathena+rest://:@localhost", "", "", "localhost", None, "", None),
+            (
+                "awsathena+rest://:@localhost:5432/database?s3_staging_dir=dir",
+                "",
+                "",
+                "localhost",
+                5432,
+                "database",
+                {"s3_staging_dir": "dir"},
+            ),
+        ],
+    )
+    def test_parsing_athena_url(self, url, username, password, hostname, port, database, query):
+        client = AthenaClient(url)
+
+        assert client.drivername == "awsathena+rest"
+        assert client.host == hostname
+        assert client.username == username
+        assert client.password == password
+        assert client.port == port
+        assert client.database == database
+        assert client.url_query == query
+
+    def test_get_df(self, mocker):
+        url = "awsathena+rest://:@localhost"
+        query = "SELECT * FROM bla"
+        params = None
+
+        mock_raw_cursor = mocker.Mock()
+        mock_raw_cursor.execute = mocker.Mock()
+
+        mock_raw_conn = mocker.Mock()
+        mock_raw_conn.cursor = mocker.Mock(return_value=mock_raw_cursor)
+
+        mocker.patch.object(AthenaClient, '_get_raw_conn', return_value=mock_raw_conn)
+
+        client = AthenaClient(url)
+        client.closed = False
+        _ = client.get_df(sql_query=query)
+
+        client._get_raw_conn.assert_called_once_with()
+        mock_raw_conn.cursor.assert_called_once_with(PandasCursor)
+        mock_raw_cursor.execute.assert_called_once_with(query, parameters=params)


### PR DESCRIPTION
By default, `pyathena` + `sqlalchemy` (as used by our `SQLAlchemyClient`) fetches query results by row.

However, `pyathena` provides a way to fetch results from the `csv` results file created by Athena inside the s3 staging dir by using [`PandasCursor`](https://pypi.org/project/PyAthena/#pandascursor):
- by setting `cursor_class=PandasCursor`  in `connetct_args`, we can speed up all queries run through the client
- by using underlying `cursor`'s `.as_pandas()` method (as done in new `.get_df()`), we can fetch all results from `csv` to a DataFrame even faster, bypassing the row-wise logic.

Example with typical timings for a large query:
```
### slow - e.g. 2min29s
with tentaclio.db(athena_url) as client:
    df = pd.read_sql_query(query, client.conn)

### faster - e.g. 1min7s
with tentaclio.clients.AthenaClient(tentaclio.credentials.authenticate(athena_url)) as client:
    df = pd.read_sql_query(query, client.conn)

### even faster - e.g. 33s
with tentaclio.clients.AthenaClient(tentaclio.credentials.authenticate(url)) as client:
    df = client.get_df(query)
```

This PR does not modify `tentaclio.db`, which always returns a generic `SQLAlchemyClient`. This could be addressed in the future.