### PR TITLE
Get rid of scheme support check

### DIFF
--- a/src/tentaclio/urls.py
+++ b/src/tentaclio/urls.py
@@ -86,7 +86,7 @@ class _WriterContextManager(ContextManager[protocols.Writer]):
 
 
 def _netloc_from_components(username=None, password=None, hostname=None, port=None):
-    """Constract network location in accordance with urllib."""
+    """Construct network location in accordance with urllib."""
     netloc = ""
     if username is not None:
         netloc += parse.quote(username, safe="")
@@ -121,11 +121,11 @@ class URL:
         self._parse_url()
 
     # Helpers:
-
     def _parse_url(self) -> None:
+        if self._url is None:
+            raise URLError("None url")
+
         parsed_url = parse.urlparse(self._url)
-        if parsed_url.scheme not in self._handler_registry:
-            raise URLError(f"URL: scheme {parsed_url.scheme} not supported")
 
         self._scheme = parsed_url.scheme
         self._username = parsed_url.username

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,6 @@ https://docs.pytest.org/en/latest/writing_plugins.html#conftest-py-plugins
 import io
 import os
 from typing import Sequence
-from urllib import parse
 
 import moto
 import pytest
@@ -72,13 +71,6 @@ class FakeHandler(object):
 @pytest.fixture
 def fake_handler():
     return FakeHandler()
-
-
-@pytest.fixture
-def register_handler(fake_handler):
-    parse.uses_netloc.append("registered")
-    URL.register_handler("registered", fake_handler)
-    return fake_handler
 
 
 # Stream fixtures

--- a/tests/unit/clients/test_base_client.py
+++ b/tests/unit/clients/test_base_client.py
@@ -7,7 +7,7 @@ from tentaclio.urls import URL
 class FakeClient(base_client.BaseClient):
     connetion = None
 
-    allowed_schemes = "registered"
+    allowed_schemes = "scheme"
 
     def _connect(self):
         # return a closable
@@ -19,32 +19,32 @@ class FakeClient(base_client.BaseClient):
 
 
 class TestBaseClient:
-    def test_create_with_string(self, register_handler):
-        url = "registered:///path"
+    def test_create_with_string(self):
+        url = "scheme:///path"
         fake_client = FakeClient(url)
 
-        assert fake_client.url.scheme == "registered"
+        assert fake_client.url.scheme == "scheme"
 
-    def test_creation_with_url(self, register_handler):
-        url = URL("registered:///path")
+    def test_creation_with_url(self):
+        url = URL("scheme:///path")
         fake_client = FakeClient(url)
-        assert fake_client.url.scheme == "registered"
+        assert fake_client.url.scheme == "scheme"
 
-    def test_closed_client_connection(self, mocker, register_handler):
-        url = "registered:///path"
+    def test_closed_client_connection(self, mocker):
+        url = "scheme:///path"
         mocked_conn = mocker.Mock()
         with FakeClient(url) as fake_client:
             fake_client.conn = mocked_conn
         mocked_conn.close.assert_called()
         assert fake_client.closed
 
-    def test_closed_if_connection_not_opened(self, mocker, register_handler):
-        url = "registered:///path"
+    def test_closed_if_connection_not_opened(self, mocker):
+        url = "scheme:///path"
         fake_client = FakeClient(url)
         assert fake_client.closed
 
-    def test_client_connected_is_not_closed(self, mocker, register_handler):
-        url = "registered:///path"
+    def test_client_connected_is_not_closed(self, mocker):
+        url = "scheme:///path"
         mocked_conn = mocker.Mock()
         with FakeClient(url) as fake_client:
             fake_client.conn = mocked_conn

--- a/tests/unit/clients/test_s3_client.py
+++ b/tests/unit/clients/test_s3_client.py
@@ -19,10 +19,6 @@ def fixture_conn():
 
 
 class TestS3Client:
-    def test_invalid_scheme(self, register_handler):
-        with pytest.raises(ValueError):
-            s3_client.S3Client("registered://file")
-
     @pytest.mark.parametrize(
         "url,username,password,hostname,path",
         [

--- a/tests/unit/credentials/test_env.py
+++ b/tests/unit/credentials/test_env.py
@@ -5,17 +5,17 @@ from tentaclio.credentials.env import add_credentials_from_env
 from tentaclio.credentials.injection import CredentialsInjector
 
 
-def test_add_credentials(register_handler):
+def test_add_credentials():
     env = {
-        "one_var": "registered://user:pass@hostname",
-        "TENTACLIO__CONN__DB": "registered://mydb/database",
+        "one_var": "scheme://user:pass@hostname",
+        "TENTACLIO__CONN__DB": "scheme://mydb/database",
     }
     injector = add_credentials_from_env(CredentialsInjector(), env)
-    assert len(injector.registry["registered"]) == 1
-    assert injector.registry["registered"][0] == urls.URL("registered://mydb/database")
+    assert len(injector.registry["scheme"]) == 1
+    assert injector.registry["scheme"][0] == urls.URL("scheme://mydb/database")
 
 
-def test_add_credentials_bad_url(register_handler):
+def test_add_credentials_bad_url():
     env = {"TENTACLIO__CONN__DB": None}
     with pytest.raises(Exception):
         add_credentials_from_env(CredentialsInjector(), env)

--- a/tests/unit/credentials/test_injection.py
+++ b/tests/unit/credentials/test_injection.py
@@ -8,63 +8,63 @@ from tentaclio.credentials import injection
     ["with_creds", "raw", "expected"],
     [
         [
-            "registered://user:password@octo.energy/path",
-            "registered://octo.energy/path",
-            "registered://user:password@octo.energy/path",
+            "scheme://user:password@octo.energy/path",
+            "scheme://octo.energy/path",
+            "scheme://user:password@octo.energy/path",
         ],
         [
-            "registered://user:password@octo.energy/path/",
-            "registered://octo.energy/path/with/more/elements",
-            "registered://user:password@octo.energy/path/with/more/elements",
+            "scheme://user:password@octo.energy/path/",
+            "scheme://octo.energy/path/with/more/elements",
+            "scheme://user:password@octo.energy/path/with/more/elements",
         ],
         [
-            "registered://user:password@octo.energy/path/",
-            "registered://octo.energy/path/with/more/elements",
-            "registered://user:password@octo.energy/path/with/more/elements",
+            "scheme://user:password@octo.energy/path/",
+            "scheme://octo.energy/path/with/more/elements",
+            "scheme://user:password@octo.energy/path/with/more/elements",
         ],
         [
-            "registered://user:password@octo.energy/database",
-            "registered://octo.energy/database::table",
-            "registered://user:password@octo.energy/database::table",
+            "scheme://user:password@octo.energy/database",
+            "scheme://octo.energy/database::table",
+            "scheme://user:password@octo.energy/database::table",
         ],
         [
-            "registered://user:password@octo.energy/database",
-            "registered://hostname/database",  # hostname wildcard
-            "registered://user:password@octo.energy/database",
+            "scheme://user:password@octo.energy/database",
+            "scheme://hostname/database",  # hostname wildcard
+            "scheme://user:password@octo.energy/database",
         ],
         [
-            "registered://user:password@octo.energy:5544/database",
-            "registered://octo.energy/database",
-            "registered://user:password@octo.energy:5544/database",
+            "scheme://user:password@octo.energy:5544/database",
+            "scheme://octo.energy/database",
+            "scheme://user:password@octo.energy:5544/database",
         ],
         [
-            "registered://user:password@octo.energy/database",
-            "registered://octo.energy/database2",
-            "registered://octo.energy/database2",  # the path is similar but not identical
+            "scheme://user:password@octo.energy/database",
+            "scheme://octo.energy/database2",
+            "scheme://octo.energy/database2",  # the path is similar but not identical
         ],
         [
-            "registered://user:password@octo.energy:5544/database?key=value",
-            "registered://octo.energy/database",
-            "registered://user:password@octo.energy:5544/database?key=value",
+            "scheme://user:password@octo.energy:5544/database?key=value",
+            "scheme://octo.energy/database",
+            "scheme://user:password@octo.energy:5544/database?key=value",
         ],
         [
-            "registered://user:password@octo.energy:5544/database?key=value_1",
-            "registered://octo.energy/database?key=value_2",
-            "registered://user:password@octo.energy:5544/database?key=value_2",
+            "scheme://user:password@octo.energy:5544/database?key=value_1",
+            "scheme://octo.energy/database?key=value_2",
+            "scheme://user:password@octo.energy:5544/database?key=value_2",
         ],
         [
-            "registered://user:password@octo.energy/",  # trailing slash
-            "registered://octo.energy/file",
-            "registered://user:password@octo.energy/file",
+            "scheme://user:password@octo.energy/",  # trailing slash
+            "scheme://octo.energy/file",
+            "scheme://user:password@octo.energy/file",
         ],
         [
-            "registered://user:password@octo.energy/",  # trailing slash
-            "registered://octo.energy/path/",
-            "registered://user:password@octo.energy/path/",
+            "scheme://user:password@octo.energy/",  # trailing slash
+            "scheme://octo.energy/path/",
+            "scheme://user:password@octo.energy/path/",
         ],
     ],
 )
-def test_simple_authenticate(with_creds, raw, expected, register_handler):
+def test_simple_authenticate(with_creds, raw, expected):
     injector = injection.CredentialsInjector()
     with_creds_url = URL(with_creds)
     raw_url = URL(raw)
@@ -88,16 +88,16 @@ def test_similarites(path_1, path_2, expected):
     assert result == expected
 
 
-def test_hostname_is_wildcard(register_handler):
+def test_hostname_is_wildcard():
     matches = injection._filter_by_hostname(
-        URL("registered://hostname/"), [URL("registered://google.com/path")]
+        URL("scheme://hostname/"), [URL("scheme://google.com/path")]
     )
-    assert matches == [URL("registered://google.com/path")]
+    assert matches == [URL("scheme://google.com/path")]
 
 
-def test_filter_by_hostname(register_handler):
+def test_filter_by_hostname():
     matches = injection._filter_by_hostname(
-        URL("registered://google.com/"),
-        [URL("registered://google.com/path"), URL("registered://yahoo.com/path")],
+        URL("scheme://google.com/"),
+        [URL("scheme://google.com/path"), URL("scheme://yahoo.com/path")],
     )
-    assert matches == [URL("registered://google.com/path")]
+    assert matches == [URL("scheme://google.com/path")]

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -58,7 +58,7 @@ def test_credentials(url, expected, creds_yaml):
     assert result == urls.URL(expected)
 
 
-def test_credentials_bad_url(register_handler, creds_yaml_bad_url):
+def test_credentials_bad_url(creds_yaml_bad_url):
     data = io.StringIO(creds_yaml_bad_url)
     with pytest.raises(Exception):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)

--- a/tests/unit/handlers/test_stream_handler.py
+++ b/tests/unit/handlers/test_stream_handler.py
@@ -24,21 +24,21 @@ class FakeClient(StreamClient):
         self._writer.seek(0)
 
 
-def test_open_reader_for_string(register_handler):
+def test_open_reader_for_string():
     handler = StreamURLHandler(FakeClient)
-    reader = handler.open_reader_for(URL("registered://my/path"), mode="t", extras={})
+    reader = handler.open_reader_for(URL("scheme://my/path"), mode="t", extras={})
     assert "hello" == reader.read()
 
 
-def test_open_reader_for_bytes(register_handler):
+def test_open_reader_for_bytes():
     message = bytes("hello", "utf-8")
     handler = StreamURLHandler(FakeClient)
-    reader = handler.open_reader_for(URL("registered://my/path"), mode="b", extras={})
+    reader = handler.open_reader_for(URL("scheme://my/path"), mode="b", extras={})
     assert message == reader.read()
 
 
-def test_open_writer_for_string(register_handler):
-    url = URL("registered://my/path")
+def test_open_writer_for_string():
+    url = URL("scheme://my/path")
     client = FakeClient(url)
     handler = StreamURLHandler(lambda url, **kwargs: client)
     writer = handler.open_writer_for(url, mode="t", extras={})
@@ -48,8 +48,8 @@ def test_open_writer_for_string(register_handler):
     assert client._writer.getvalue().decode("utf-8") == "test"
 
 
-def test_open_writer_for_bytes(register_handler):
-    url = URL("registered://my/path")
+def test_open_writer_for_bytes():
+    url = URL("scheme://my/path")
     client = FakeClient(url)
     handler = StreamURLHandler(lambda url, **kwargs: client)
     writer = handler.open_writer_for(url, mode="b", extras=dict())

--- a/tests/unit/test_urls.py
+++ b/tests/unit/test_urls.py
@@ -29,25 +29,15 @@ class TestURL:
         with pytest.raises(urls.URLError):
             urls.URL(None)
 
-    def test_unknown_url_scheme(self):
-        url = "notregistered://localhost"
-        with pytest.raises(urls.URLError):
-            urls.URL(url)
-
-    def test_known_url_scheme(self, register_handler):
-        url = "registered://localhost"
-        # well, this shouldn't blow
-        urls.URL(url)
-
     @pytest.mark.parametrize(
         "url,username,password",
         [
-            ("registered://:@localhost", "", ""),
-            ("registered://abc_def%40123.com:@localhost", "abc_def@123.com", ""),
-            ("registered://:%40%60%60Z_%24-%24%405%25Ky%2F@localhost", "", "@``Z_$-$@5%Ky/"),
+            ("scheme://:@localhost", "", ""),
+            ("scheme://abc_def%40123.com:@localhost", "abc_def@123.com", ""),
+            ("scheme://:%40%60%60Z_%24-%24%405%25Ky%2F@localhost", "", "@``Z_$-$@5%Ky/"),
         ],
     )
-    def test_url_escaped_fields(self, url, username, password, register_handler):
+    def test_url_escaped_fields(self, url, username, password):
         parsed_url = urls.URL(url)
 
         assert parsed_url.username == username
@@ -71,8 +61,8 @@ class TestURL:
         "url,scheme,username,password,hostname,port,path,query",
         [
             (
-                "registered:///path/to/file.ext",
-                "registered",
+                "scheme:/path/to/file.ext",
+                "scheme",
                 None,
                 None,
                 None,
@@ -81,8 +71,8 @@ class TestURL:
                 None,
             ),
             (
-                "registered://login:pass@localhost?key=value",
-                "registered",
+                "scheme://login:pass@localhost?key=value",
+                "scheme",
                 "login",
                 "pass",
                 "localhost",
@@ -91,8 +81,8 @@ class TestURL:
                 {"key": "value"},
             ),
             (
-                "registered://:@localhost:5432/database",
-                "registered",
+                "scheme://:@localhost:5432/database",
+                "scheme",
                 "",
                 "",
                 "localhost",
@@ -101,8 +91,8 @@ class TestURL:
                 {},
             ),
             (
-                "registered://log%3Ain:pass%2Fword@localhost/path/to?spaced+key=odd%2Fva%3B%3Alue",
-                "registered",
+                "scheme://log%3Ain:pass%2Fword@localhost/path/to?spaced+key=odd%2Fva%3B%3Alue",
+                "scheme",
                 "log:in",
                 "pass/word",
                 "localhost",
@@ -113,7 +103,7 @@ class TestURL:
         ],
     )
     def test_url_from_components(
-        self, url, scheme, username, password, hostname, port, path, query, register_handler
+        self, url, scheme, username, password, hostname, port, path, query
     ):
         parsed_url = urls.URL.from_components(
             scheme=scheme,
@@ -136,57 +126,57 @@ class TestURL:
     @pytest.mark.parametrize(
         ["url_1", "url_2", "should_be_equal"],
         [
-            ["registered://user:pass@host/path", "registered://user:pass@host/path", True],
-            ["registered://host/path", "registered://host/path", True],
-            ["registered://host/path?key=value", "registered://host/path?key=value", True],
-            ["registered://host/path", "registered://host/path?key=value", False],
-            ["registered://host/path", "registered://user:pass@host/path", False],
-            ["registered://host/path1", "registered://host/path2", False],
+            ["scheme://user:pass@host/path", "scheme://user:pass@host/path", True],
+            ["scheme://host/path", "scheme://host/path", True],
+            ["scheme://host/path?key=value", "scheme://host/path?key=value", True],
+            ["scheme://host/path", "scheme://host/path?key=value", False],
+            ["scheme://host/path", "scheme://user:pass@host/path", False],
+            ["scheme://host/path1", "scheme://host/path2", False],
         ],
     )
-    def test_url_equality(self, url_1, url_2, should_be_equal, register_handler):
+    def test_url_equality(self, url_1, url_2, should_be_equal):
         assert (urls.URL(url_1) == urls.URL(url_2)) == should_be_equal
 
     @pytest.mark.parametrize(
         "original,components,expected",
         [
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"username": "myuser"},
-                "registered://myuser:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://myuser:password@hostname.com:7744/path?my_arg=my_value",
             ),
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"password": "mypassword"},
-                "registered://user:mypassword@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:mypassword@hostname.com:7744/path?my_arg=my_value",
             ),
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"hostname": "google.com"},
-                "registered://user:password@google.com:7744/path?my_arg=my_value",
+                "scheme://user:password@google.com:7744/path?my_arg=my_value",
             ),
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"port": 80},
-                "registered://user:password@hostname.com:80/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:80/path?my_arg=my_value",
             ),
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"path": "otherpath"},
-                "registered://user:password@hostname.com:7744/otherpath?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/otherpath?my_arg=my_value",
             ),
             (
-                "registered://user:password@hostname.com:7744/path?my_arg=my_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=my_value",
                 {"query": {"my_arg": "other_value"}},
-                "registered://user:password@hostname.com:7744/path?my_arg=other_value",
+                "scheme://user:password@hostname.com:7744/path?my_arg=other_value",
             ),
         ],
     )
-    def test_copy(self, original, components, expected, register_handler):
+    def test_copy(self, original, components, expected):
         result = urls.URL(original).copy(**components)
         assert result == urls.URL(expected)
 
-    def test_string_hides_password(self, register_handler):
-        original = urls.URL("registered://user:password@hostname.com")
+    def test_string_hides_password(self):
+        original = urls.URL("scheme://user:password@hostname.com")
         str_url = str(original)
-        assert str_url == "registered://user:__secret__word@hostname.com"
+        assert str_url == "scheme://user:__secret__word@hostname.com"


### PR DESCRIPTION
Prior to this change the url class will try to check if the scheme is
supported in the context of tentaclio. Adding more types of registers
will make this check complicated and definitively the url class is not
the place to do it.