### PR TITLE
Redesign base client

### DIFF
--- a/src/tentaclio/clients/__init__.py
+++ b/src/tentaclio/clients/__init__.py
@@ -11,3 +11,4 @@ from .postgres_client import *  # noqa
 from .s3_client import *  # noqa
 from .sqla_client import *  # noqa
 from .athena_client import *  # noqa
+from .protocols import * # noqa

--- a/src/tentaclio/clients/ftp_client.py
+++ b/src/tentaclio/clients/ftp_client.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 __all__ = ["FTPClient", "SFTPClient"]
 
 
-class FTPClient(base_client.StreamClient):
+class FTPClient(base_client.BaseClient["FTPClient"]):
     """Generic FTP client."""
 
     allowed_schemes = ["ftp"]
@@ -79,7 +79,7 @@ class FTPClient(base_client.StreamClient):
             return False
 
 
-class SFTPClient(base_client.StreamClient):
+class SFTPClient(base_client.BaseClient["SFTPClient"]):
     """SFTP stream client."""
 
     allowed_schemes = ["sftp"]

--- a/src/tentaclio/clients/http_client.py
+++ b/src/tentaclio/clients/http_client.py
@@ -18,7 +18,9 @@ DEFAULT_TIMEOUT = 10.0
 DEFAULT_HEADERS = {"Accept": "application/json"}
 
 
-class HTTPClient(base_client.StreamClient):
+class HTTPClient(
+    base_client.BaseClient["HTTPClient"]
+):
     """HTTP stream client.
 
     This client is useful when dealing inputs that may change from local files to http,

--- a/src/tentaclio/clients/protocols.py
+++ b/src/tentaclio/clients/protocols.py
@@ -1,0 +1,51 @@
+"""Clients protocols."""
+import abc
+from typing import Iterable
+
+from typing_extensions import Protocol
+
+from tentaclio import protocols
+
+
+__all__ = ["Streamer", "DirScanner"]
+
+
+class Streamer(Protocol):
+    """Interface for stream-based connections."""
+
+    # Stream methods:
+
+    @abc.abstractmethod
+    def get(self, writer: protocols.ByteWriter, **params) -> None:
+        """Read the contents from the stream and write them the the ByteWriter."""
+        ...
+
+    @abc.abstractmethod
+    def put(self, reader: protocols.ByteReader, **params) -> None:
+        """Write the contents of the reader into the client stream."""
+        ...
+
+
+class DirScanner(Protocol):
+    """DirScanner."""
+
+    @abc.abstractmethod
+    def scan_dir(self, **params) -> None:
+        """Scan dir-like urls."""
+        ...
+
+
+class QueryClient(Protocol):
+    """Interface for query-based connections."""
+
+    # Query methods:
+
+    @abc.abstractmethod
+    def execute(self, sql_query: str, **params) -> None:
+        """Execute a query against the underlying client."""
+        ...
+
+    @abc.abstractmethod
+    def query(self, sql_query: str, **params) -> Iterable:
+        """Perform the query and return an iterable of the results."""
+        ...

--- a/src/tentaclio/clients/s3_client.py
+++ b/src/tentaclio/clients/s3_client.py
@@ -12,7 +12,7 @@ from . import base_client, decorators, exceptions
 __all__ = ["S3Client"]
 
 
-class S3Client(base_client.StreamClient):
+class S3Client(base_client.BaseClient["S3Client"]):
     """S3 client, backed by boto3.
 
     Ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -23,7 +23,7 @@ __all__ = ["SQLAlchemyClient", "bound_session", "atomic_session"]
 SessionGenerator = Generator[None, session.Session, None]
 
 
-class SQLAlchemyClient(base_client.QueryClient):
+class SQLAlchemyClient(base_client.BaseClient["SQLAlchemyClient"]):
     """SQLAlchemy based client."""
 
     # The allowed drivers depend on the dependencies installed.

--- a/tests/unit/clients/test_s3_client.py
+++ b/tests/unit/clients/test_s3_client.py
@@ -1,6 +1,5 @@
 import io
 
-import moto
 import pytest
 
 from tentaclio.clients import exceptions, s3_client
@@ -8,14 +7,8 @@ from tentaclio.clients import exceptions, s3_client
 
 @pytest.fixture()
 def mocked_conn(mocker):
-    with mocker.patch.object(s3_client.S3Client, "_connect", return_value=mocker.Mock()):
-        yield
-
-
-@pytest.fixture()
-def fixture_conn():
-    with moto.mock_s3():
-        yield
+    with mocker.patch.object(s3_client.S3Client, "_connect", return_value=mocker.Mock()) as m:
+        yield m
 
 
 class TestS3Client:

--- a/tests/unit/handlers/test_stream_handler.py
+++ b/tests/unit/handlers/test_stream_handler.py
@@ -1,11 +1,11 @@
 import io
 
 from tentaclio import URL, Reader, Writer
-from tentaclio.clients.base_client import StreamClient
+from tentaclio.clients import base_client
 from tentaclio.handlers.stream_handler import StreamURLHandler
 
 
-class FakeClient(StreamClient):
+class FakeClient(base_client.BaseClient["FakeClient"]):
     # clients only understand bytes
     def __init__(self, url: URL, message: bytearray = None):
         self._writer = io.BytesIO()

--- a/tests/unit/streams/test_base_stream.py
+++ b/tests/unit/streams/test_base_stream.py
@@ -3,12 +3,12 @@ import io
 from tentaclio.streams import base_stream
 
 
-class TestStreamClientWriter:
+class TestStreamerWriter:
     def test_write(self, mocker):
         client = mocker.MagicMock()
         buff = io.StringIO()
 
-        writer = base_stream.StreamClientWriter(client, buff)
+        writer = base_stream.StreamerWriter(client, buff)
         writer.write("hello")
         assert "hello" == buff.getvalue()
 
@@ -16,20 +16,20 @@ class TestStreamClientWriter:
         client = mocker.MagicMock()
         buff = io.StringIO()
 
-        writer = base_stream.StreamClientWriter(client, buff)
+        writer = base_stream.StreamerWriter(client, buff)
         writer.close()
 
         assert buff.closed
         client.put.assert_called()
 
 
-class TestStreamClientReader:
+class TestStreamerReader:
     def test_read(self, mocker):
         client = mocker.MagicMock()
         expected = bytes("hello world", "utf-8")
         client.get = lambda f: f.write(expected)
 
-        reader = base_stream.StreamClientReader(client, io.BytesIO())
+        reader = base_stream.StreamerReader(client, io.BytesIO())
         contents = reader.read()
         assert expected == contents
 
@@ -39,14 +39,14 @@ class TestStreamClientReader:
         retrieved = expected + bytes("this is a new line", "utf-8")
         client.get = lambda f: f.write(retrieved)
 
-        reader = base_stream.StreamClientReader(client, io.BytesIO())
+        reader = base_stream.StreamerReader(client, io.BytesIO())
         contents = reader.readline()
         assert expected == contents
 
     def test_close(self, mocker):
         client = mocker.MagicMock()
 
-        reader = base_stream.StreamClientReader(client, io.BytesIO())
+        reader = base_stream.StreamerReader(client, io.BytesIO())
         reader.close()
 
         assert reader.buffer.closed


### PR DESCRIPTION
Before we were using a more OOP approach with clients based on
inheritance. Clients are going to become richer but their features are
going to be more disjoint. i.e S3 client will support streaming and
listing, but not http etc. In order to avoid growing the StreamClient
class and have a more modular design, streaming/listing/querying will be
protocols, allowing to offer the desired functionality per client
without over complicating the inheritance tree.