### PR TITLE
Implement PostgresClient.get_df using COPY

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.8] - 2020-03-19
+### Added
+ - `PostgresClient.get_df_unsafe()` using COPY for faster Postgres queries
+
 ## [0.0.1-alpha.7] - 2020-03-18
 ### Changed 
  -  Do not check if the resource is a file before retrieval in the ftp client. The method might not
@@ -11,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.0.1-alpha.6] - 2020-03-18
 ### Added
- -  Allow ftp scandir fallback to dir when mlst is not implemented on the server
+ - Allow ftp scandir fallback to dir when mlst is not implemented on the server
 
 ## [0.0.1-alpha.5] - 2020-02-12
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.1-alpha.7"
+VERSION = "0.0.1-alpha.8"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/tests/functional/postgres/test_api.py
+++ b/tests/functional/postgres/test_api.py
@@ -36,12 +36,12 @@ def fixture_df():
 
 def test_authenticated_api_calls(fixture_client, fixture_df):
     with tentaclio.open(
-        f"postgresql://hostname/tentaclio-db::{TEST_TABLE_NAME}", mode="w"
+        f"postgresql://hostname{fixture_client.url.path}::{TEST_TABLE_NAME}", mode="w"
     ) as writer:
         fixture_df.to_csv(writer, index=False)
 
     with clients.PostgresClient(
-        credentials.authenticate("postgresql://hostname/tentaclio-db")
+        credentials.authenticate(f"postgresql://hostname{fixture_client.url.path}")
     ) as client:
         retrieved_df = client.get_df(f"select * from {TEST_TABLE_NAME}")
 

--- a/tests/functional/postgres/test_client.py
+++ b/tests/functional/postgres/test_client.py
@@ -47,3 +47,9 @@ class TestPostgresClient:
         retrieved_df = fixture_client.get_df(f"SELECT * FROM {TEST_TABLE_NAME};")
 
         assert retrieved_df.equals(fixture_df)
+
+    def test_dumping_and_getting_df_unsafe(self, fixture_client, fixture_df):
+        fixture_client.dump_df(fixture_df, TEST_TABLE_NAME)
+        retrieved_df = fixture_client.get_df_unsafe(f"SELECT * FROM {TEST_TABLE_NAME};")
+
+        assert retrieved_df.equals(fixture_df)


### PR DESCRIPTION
Streaming results as CSV to STDOUT

## Example

```python
import tentaclio as tio

query = "SELECT * FROM table LIMIT 1000000"
url = tio.api.authenticate("postgresql://hostname/db_name")

%%time  # Wall time: 113s
with tio.clients.sqla_client.SQLAlchemyClient(url) as c:
    df = c.get_df(query)

%%time  # Wall time: 51s
with tio.clients.postgres_client.PostgresClient(url) as c:
    df = c.get_df(query)
```