### PR TITLE
Restrict pandas version due to incompatibility on IO streams

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,12 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.9] - 2020-03-27
+### Changed
+ - Enforce versioning on `pandas` due to compatibility issues with the new I/O API (v1.0.2)
+
 ## [0.0.1-alpha.8] - 2020-03-19
 ### Added
  - `PostgresClient.get_df_unsafe()` using COPY for faster Postgres queries
 
 ## [0.0.1-alpha.7] - 2020-03-18
-### Changed 
+### Changed
  -  Do not check if the resource is a file before retrieval in the ftp client. The method might not
  be implemented and the server will complain regardless.
 
@@ -26,17 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Support deleting resources (S3 and local file system ).
  - Support for copying any arbitrary pair of resources.
  - Support for copying S3 files using aws boto directly.
-### Changed  
+### Changed
  - Removed a duplication of the main api.
 
 ## [0.0.1-alpha.3] - 2019-07-24
 ### Added
  - Support for listing resources (S3, local file system, sftp, and ftp schemes).
  - More internal registries for more types of handlers.
-### Changed  
+### Changed
  - URL class no longer contains the stream handlers.
 
 ## [0.0.1-alpha.2] - 2019-07-24
-### Added 
+### Added
  - Athena client.
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ REQUIREMENTS = [
     "pysftp>=0.2.0,<0.3",
     # Utils
     "typing-extensions",
-    "pandas",
+    "pandas<1.0.2",
     "click",
     "pyyaml",
 ]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.1-alpha.8"
+VERSION = "0.0.1-alpha.9"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
Breaking compatibility on `pandas==1.0.2` with regards to IO stream handling.

https://pandas.pydata.org/pandas-docs/stable/whatsnew/v1.0.2.html
https://github.com/pandas-dev/pandas/blob/v1.0.0/pandas/io/parsers.py#L1879