### PR TITLE
Fix `params` kwarg in `SQLAlchemyClient.query()` and `.execute()``

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.1-alpha.10] - 2020-05-14
+### Fixed
+ - `SQLAlchemyClient.query()` now takes an explicit `params` kwarg consistent with `conn.execute()`
+
 ## [0.0.1-alpha.9] - 2020-03-27
 ### Changed
  - Enforce versioning on `pandas` due to compatibility issues with the new I/O API (v1.0.2)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.1-alpha.9"
+VERSION = "0.0.1-alpha.10"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -116,19 +116,19 @@ class SQLAlchemyClient(base_client.BaseClient["SQLAlchemyClient"]):
     # Query methods:
 
     @decorators.check_conn
-    def query(self, sql_query: str, **params) -> result.ResultProxy:
+    def query(self, sql_query: str, params: dict = None, **kwargs) -> result.ResultProxy:
         """Execute a read-only SQL query, and return results.
 
         This will not commit any changes to the database.
         """
-        return self.conn.execute(sql_query, params=params)
+        return self.conn.execute(sql_query, params=params, **kwargs)
 
     @decorators.check_conn
-    def execute(self, sql_query: str, **params) -> None:
+    def execute(self, sql_query: str, params: dict = None, **kwargs) -> None:
         """Execute a raw SQL query command."""
         trans = self.conn.begin()
         try:
-            self.conn.execute(sql_query, params=params)
+            self.conn.execute(sql_query, params=params, **kwargs)
         except Exception:
             trans.rollback()
             raise


### PR DESCRIPTION
Before this change, params passed to `self.conn.execute` was always an (empty) dict. This is inconsistent with at least some SQLAlchemy clients. After this change, the default value is `params=None`, which works with Postgres and Athena clients.