### PR TITLE
Set the pg applicationName from the env

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.2] - 2020-07-02
+### Added
+ - TENCACLIO__PG_APPLICATION_NAME overrides the application name for postgres connection string 
+
 ## [0.0.1] - 2020-06-15
 ### Added
  - support for google cloud storage (thanks to @benjamincerigo)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ The supported db schemes are:
 * `mssql://`
 * Any other scheme supported by sqlalchemy.
 
+#### Extras for databases
+For postgres you can set the variable `TENTACLIO__PG_APPLICATION_NAME` and the value will be injected 
+when connecting to the database.
+
 ### Automatic credentials injection
 
 1. Configure credentials by using environmental variables prefixed with `TENTACLIO__CONN__`  (i.e.  `TENTACLIO__CONN__DATA_FTP=sfpt://real_user:132ldsf@ftp.octoenergy.com`).

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.1"
+VERSION = "0.0.2"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/postgres_client.py
+++ b/src/tentaclio/clients/postgres_client.py
@@ -5,6 +5,7 @@ which is more performant than using sql alchemy functions.
 """
 
 import io
+import os
 from typing import Sequence
 
 import pandas as pd
@@ -18,9 +19,24 @@ __all__ = ["PostgresClient"]
 
 
 class PostgresClient(sqla_client.SQLAlchemyClient):
-    """Postgres client, backed by a SQLAlchemy connection."""
+    """Postgres client, backed by a SQLAlchemy connection.
+
+    While connecting will check TENTACLIO__PG_APPLICATION_NAME to set
+    the applicationName in the connection string.
+    """
+
+    TENTACLIO__PG_APPLICATION_NAME = "TENTACLIO__PG_APPLICATION_NAME"
 
     allowed_schemes = ["postgresql"]
+
+    def _extract_url_params(self):
+        super()._extract_url_params()
+        applicationName = os.getenv(self.TENTACLIO__PG_APPLICATION_NAME, "")
+        if applicationName != "":
+            if self.url_query is None:
+                self.url_query = {}
+            # overrides the value that might be set in the tentaclio file
+            self.url_query["applicationName"] = applicationName
 
     # Postgres Copy Expert methods:
     @decorators.check_conn

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -66,7 +66,10 @@ class SQLAlchemyClient(base_client.BaseClient["SQLAlchemyClient"]):
         self.execution_options = execution_options or {}
         self.connect_args = connect_args or self.connect_args_default
         super().__init__(url)
+        self._extract_url_params()
 
+    def _extract_url_params(self) -> None:
+        """Extract the database parameters from the url."""
         # the database doesn't start with /
         database = self.url.path[1:]
 

--- a/tests/unit/clients/test_postgres_client.py
+++ b/tests/unit/clients/test_postgres_client.py
@@ -10,15 +10,24 @@ class TestPostgresClient:
             postgres_client.PostgresClient(url)
 
     @pytest.mark.parametrize(
-        "url, username, password, hostname, port, database",
+        "url, username, password, hostname, port, database, query",
         [
-            ("postgresql://:@localhost", "", "", "localhost", None, ""),
-            ("postgresql://login:pass@localhost", "login", "pass", "localhost", None, ""),
-            ("postgresql://:@localhost:5432", "", "", "localhost", 5432, ""),
-            ("postgresql://:@localhost:5432/database", "", "", "localhost", 5432, "database"),
+            ("postgresql://:@localhost", "", "", "localhost", None, "", None),
+            ("postgresql://login:pass@localhost", "login", "pass", "localhost", None, "", None),
+            ("postgresql://:@localhost:5432", "", "", "localhost", 5432, "", None),
+            (
+                "postgresql://:@localhost:5432/database",
+                "",
+                "",
+                "localhost",
+                5432,
+                "database",
+                None,
+            ),
+            ("postgresql://localhost?limit=3", None, None, "localhost", None, "", {"limit": "3"}),
         ],
     )
-    def test_parsing_postgres_url(self, url, username, password, hostname, port, database):
+    def test_parsing_postgres_url(self, url, username, password, hostname, port, database, query):
         client = postgres_client.PostgresClient(url)
 
         assert client.drivername == "postgresql"
@@ -27,3 +36,13 @@ class TestPostgresClient:
         assert client.password == password
         assert client.port == port
         assert client.database == database
+        assert client.url_query == query
+
+    @pytest.mark.parametrize(
+        "env_value, expected", (("test", {"applicationName": "test"}), ("", None),)
+    )
+    def test_add_application_name_from_env(self, mocker, env_value, expected):
+        mocked_os = mocker.patch("tentaclio.clients.postgres_client.os")
+        mocked_os.getenv.return_value = env_value
+        client = postgres_client.PostgresClient("postgresql://hostname/db")
+        assert client.url_query == expected


### PR DESCRIPTION
We've been doing this from the tentaclio file so far. But for dynamic 
systems we need this piece of functionaly to easily filter queries