### PR TITLE
Use UserProfile instead of HOME in win systems

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.6] - 2020-08-25
+### Fix 
+  - Windows based system don not have the HOME environment variable set by default. 
+  Fixed by using UserProfile instead.
+
 ## [0.0.5] - 2020-08-02
 ### Fix 
  - Fix problems with base stream as it needed to make itself as fushable 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.5"
+VERSION = "0.0.6"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/google_drive_client.py
+++ b/src/tentaclio/clients/google_drive_client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import mimetypes
 import os
+import platform
 from dataclasses import dataclass
 from typing import Any, Dict, Generic, Iterable, List, Optional, Tuple, TypeVar, Union
 
@@ -22,7 +23,12 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["GoogleDriveFSClient"]
 
-DEFAULT_TOKEN_FILE = os.environ["HOME"] + os.sep + ".tentaclio_google_drive.json"
+if "windows" in platform.system().lower():
+    HOME = os.environ["UserProfile"]
+else:
+    HOME = os.environ["HOME"]
+
+DEFAULT_TOKEN_FILE = HOME + os.sep + ".tentaclio_google_drive.json"
 # Load the location of the token file from the environment
 TOKEN_FILE = os.getenv("TENTACLIO__GOOGLE_DRIVE_TOKEN_FILE", DEFAULT_TOKEN_FILE)
 


### PR DESCRIPTION
A change in the latest version broke windows compatibility. here the fix grab the right environmental variable when the system is windows.
 
as per https://superuser.com/questions/607105/is-the-home-environment-variable-normally-set-in-windows