### PR TITLE
Filter credentials by username

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.9] - 2020-08-27
+### Addition 
+  - Allow filtering credentials by username in the url too. Until now we were relying on scheme,
+  hostname, and path.
+
 ## [0.0.8] - 2020-08-27
 ### Fix
   - Add dataclasses dependency to support python 3.6.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.8"
+VERSION = "0.0.9"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/credentials/injection.py
+++ b/src/tentaclio/credentials/injection.py
@@ -30,7 +30,8 @@ class CredentialsInjector(object):
         """Inject credentials to the given url if they are available."""
         creds_by_scheme = self.registry[url.scheme]
         creds_by_host = _filter_by_hostname(url, creds_by_scheme)
-        candidates = _filter_by_path(url, creds_by_host)
+        creds_by_path = _filter_by_path(url, creds_by_host)
+        candidates = _filter_by_user(url, creds_by_path)
 
         if len(candidates) == 0:
             return url
@@ -73,6 +74,12 @@ def _filter_by_hostname(url: urls.URL, to_match: List[urls.URL]) -> List[urls.UR
     if url.hostname != "hostname":
         return list(filter(lambda cred: cred.hostname == url.hostname, to_match))
     return to_match
+
+
+def _filter_by_user(url: urls.URL, to_match: List[urls.URL]) -> List[urls.URL]:
+    if url.username is None:
+        return to_match
+    return list(filter(lambda cred: cred.username == url.username, to_match))
 
 
 PATH_DELIMITERS = "/|::"

--- a/tests/unit/credentials/test_injection.py
+++ b/tests/unit/credentials/test_injection.py
@@ -62,6 +62,16 @@ from tentaclio.credentials import injection
             "scheme://octo.energy/path/",
             "scheme://user:password@octo.energy/path/",
         ],
+        [
+            "scheme://user:password@octo.energy/path",  # specifying user
+            "scheme://user:@octo.energy/path",
+            "scheme://user:password@octo.energy/path",
+        ],
+        [
+            "scheme://octo.energy/path",  # specified user not found
+            "scheme://user:@octo.energy/path",
+            "scheme://user:@octo.energy/path",
+        ],
     ],
 )
 def test_simple_authenticate(with_creds, raw, expected):


### PR DESCRIPTION
Until now were filtering credentials by:
   * scheme
   * hostname
   * path

   We have found a usecase where we need to access a resource with different
   priviledges, therefore we need to support injecting the right credentials
   given the username.

   The filtering process takes into account now:

   * scheme
   * hostname
   * path
   * username