### PR TITLE
Fallback for DEFAULT_TOKEN_FILE

### DIFF
--- a/src/tentaclio/clients/google_drive_client.py
+++ b/src/tentaclio/clients/google_drive_client.py
@@ -23,12 +23,25 @@ logger = logging.getLogger(__name__)
 
 __all__ = ["GoogleDriveFSClient"]
 
-if "windows" in platform.system().lower():
-    HOME = os.environ["UserProfile"]
-else:
-    HOME = os.environ["HOME"]
 
-DEFAULT_TOKEN_FILE = HOME + os.sep + ".tentaclio_google_drive.json"
+def _get_default_token_file():
+    """Get default token file path.
+
+    Includes a fallback of the current working directory.
+    If the user profile environment variables are not set.
+    """
+    if "windows" in platform.system().lower():
+        HOME = os.environ.get("UserProfile")
+    else:
+        HOME = os.environ.get("HOME")
+
+    if not HOME:
+        HOME = os.getcwd()
+
+    return HOME + os.sep + ".tentaclio_google_drive.json"
+
+
+DEFAULT_TOKEN_FILE = _get_default_token_file()
 # Load the location of the token file from the environment
 TOKEN_FILE = os.getenv("TENTACLIO__GOOGLE_DRIVE_TOKEN_FILE", DEFAULT_TOKEN_FILE)
 

--- a/tests/unit/clients/test_google_drive_client.py
+++ b/tests/unit/clients/test_google_drive_client.py
@@ -15,7 +15,8 @@ from tentaclio.clients.google_drive_client import (
     _ListDrivesRequest,
     _ListFilesRequest,
     _load_credentials,
-    _UpdateRequest
+    _UpdateRequest,
+    _get_default_token_file
 )
 
 
@@ -457,3 +458,28 @@ def test_get_drive_root(mocker, file_props, file_descriptor):
 
     descriptor = _get_drive_root(service, "drive")
     assert descriptor.id_ == "root"
+
+
+def test_home_varible_set(mocker):
+    """Test DEFAULT_TOKEN_FILE is correct."""
+    env_dict = {"HOME": "/home"}
+    expected_token_file = "/home/.tentaclio_google_drive.json"
+    mocker.patch("os.environ", env_dict)
+    assert _get_default_token_file() == expected_token_file
+
+
+def test_home_varible_set_windows(mocker):
+    """Test DEFAULT_TOKEN_FILE is correct."""
+    env_dict = {"UserProfile": "/user-profile", "HOME": "/home"}
+    expected_token_file = "/user-profile/.tentaclio_google_drive.json"
+    mocker.patch("platform.system", lambda: "windows")
+    mocker.patch("os.environ", env_dict)
+    assert _get_default_token_file() == expected_token_file
+
+
+def test_home_varible_set_no_home(mocker):
+    """Test DEFAULT_TOKEN_FILE is correct."""
+    expected_token_file = "/cwd/.tentaclio_google_drive.json"
+    mocker.patch("os.getcwd", lambda: "/cwd")
+    mocker.patch("os.environ", {})
+    assert _get_default_token_file() == expected_token_file


### PR DESCRIPTION
We have been having some problems with a process that is running papermill that does not have `HOME`. (Bloody GCP DataProc,😒 ). Thus this is a fix if the environment variables are not set for the user profile the current working directory is used.