### PR TITLE
Ignore permission errors while geting gdrives

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.11] - 2020-09-23
+### Fix
+  - When we have access to a file in a shared drive but not to the drive itself it 
+  breaks the routine to "mount" the drives, as it can't access the root. Ignore those
+  drives by the time being and warn the user.
+
 ## [0.0.10] - 2020-09-18
 ### Fix
   - Specify PyAthena version to prevent errors from current release

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.10"
+VERSION = "0.0.11"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/tests/unit/clients/test_google_drive_client.py
+++ b/tests/unit/clients/test_google_drive_client.py
@@ -410,6 +410,17 @@ class TestListDrivesRequest:
         assert descriptor.name == drive_props["name"]
         assert descriptor.root_descriptor == file_descriptor
 
+    def test_yielder_permission_error(self, mocker, drive_props, file_descriptor):
+        mocked_get_drive_root = mocker.patch(
+            "tentaclio.clients.google_drive_client._get_drive_root"
+        )
+        mocked_get_drive_root.side_effect = [IOError("No files found while inspecting drive")]
+
+        service = mocker.MagicMock()
+        lister = _ListDrivesRequest(service)
+
+        assert len(list(lister._yielder({"drives": [drive_props]}))) == 0
+
 
 def test_get_random_parent_no_children(mocker):
     service = mocker.MagicMock()


### PR DESCRIPTION
There is a case in which we can have access to files withing shared drives
but not have access to the drive itself. As per now we rely on having total
access to the drive to operate we will ignore those shared drives