### PR TITLE
Filter token fields

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,9 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.12] - 2020-09-24
+### Fix
+  - The token from google might have extra fields that cause the authentication process to fail
+
 ## [0.0.11] - 2020-09-23
 ### Fix
-  - When we have access to a file in a shared drive but not to the drive itself it 
+  - When we have access to a file in a shared drive but not to the drive itself it
   breaks the routine to "mount" the drives, as it can't access the root. Ignore those
   drives by the time being and warn the user.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "0.0.11"
+VERSION = "0.0.12"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/google_drive_client.py
+++ b/src/tentaclio/clients/google_drive_client.py
@@ -32,6 +32,16 @@ DEFAULT_TOKEN_FILE = HOME + os.sep + ".tentaclio_google_drive.json"
 # Load the location of the token file from the environment
 TOKEN_FILE = os.getenv("TENTACLIO__GOOGLE_DRIVE_TOKEN_FILE", DEFAULT_TOKEN_FILE)
 
+# fetch only the needed entries fron the json file for the credentials
+GOOGLE_CREDENTIALS_ENTRIES = {
+    "client_secret",
+    "client_id",
+    "token",
+    "token_uri",
+    "refresh_token",
+    "scopes",
+}
+
 # Generic type
 T = TypeVar("T")
 
@@ -45,6 +55,7 @@ def _load_credentials(token_file: str) -> Credentials:
     if os.path.exists(token_file):
         with open(token_file) as f:
             state = json.load(f)
+            state = {key: state[key] for key in state if key in GOOGLE_CREDENTIALS_ENTRIES}
             creds = Credentials(**state)
     else:
         raise ValueError(f"Token file is not valid {token_file}")


### PR DESCRIPTION
The token from google may come with some extra metada not allowed by the
`Credentials` constructor, filter only those fields that we need to call
the api