### PR TITLE
Temporarily pin sqlalchemy < 1.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS = [
     # Postgres
     "psycopg2-binary",
     # Sqlalchemy
-    "sqlalchemy>1.3",
+    "sqlalchemy<1.4",
     # Athena
     "PyAthena==1.10.7",
     # SFTP


### PR DESCRIPTION
Sqlalchemy 1.4 drops ResultProxy in favour of CursorResult

- https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_4_0b1