### PR TITLE
Temporarily pin sqlalchemy < 1.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.14] - 2021-03-17
+### Fix
+  - Temporarily pin sqlalchemy to <1.4 due to deprecated ResultProxy interface
 
 ## [0.0.13] - 2020-10-30
-### Addition 
-  - Update to pandas 1.1.3 by E.on request 
+### Addition
+  - Update to pandas 1.1.3 by E.on request
 
 ## [0.0.12] - 2020-09-24
 ### Fix

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ REQUIREMENTS = [
     # Postgres
     "psycopg2-binary",
     # Sqlalchemy
-    "sqlalchemy>1.3",
+    "sqlalchemy<1.4",
     # Athena
     "PyAthena==1.10.7",
     # SFTP


### PR DESCRIPTION
Sqlalchemy 1.4 drops ResultProxy in favour of CursorResult

• https://github.com/sqlalchemy/sqlalchemy/releases/tag/rel_1_4_0b1