### PR TITLE
Pin databricks + pandas dependencies

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2022-01-18
+### Changed
+  - Pin databricks plugin to thrift version
+  - Pin pandas<1.4 to avoid sqlalchemy dependency clash
+
 ## [1.0.2] - 2022-01-18
 ### Changed
   - Automatically import plugins

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.0.2"
+VERSION = "1.0.3"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,13 @@ REQUIREMENTS = [
     # Http
     "requests",
     # Sqlalchemy
+    # Pinned due to incompatibility with base client
     "sqlalchemy<1.4",
     # SFTP
     "pysftp>=0.2.0,<0.3",
     # Utils
-    "pandas",
+    # Pinned to due requiring sqlalchemy>=1.4
+    "pandas<1.4",
     "click",
     "pyyaml",
     "importlib_metadata",

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ PLUGINS = {
     "s3": "tentaclio_s3",
     "athena": "tentaclio_athena",
     "postgres": "tentaclio_postgres",
-    "databricks": "tentaclio_databricks",
+    "databricks": "tentaclio_databricks>=1.0.0",
     "gdrive": "tentaclio_gdrive",
     "gs": "tentaclio_gs",
 }


### PR DESCRIPTION
- Pin `tentaclio-databricks` to thrift version
- Pin pandas <1.4 due to sqlalchemy requirement
https://pandas.pydata.org/pandas-docs/dev/whatsnew/v1.4.0.html#backwards-incompatible-api-changes