### PR TITLE
Use sqlalchemy>=1.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2022-03-04
+### Changed
+  - Replace sqlalchemy's result.ResultProxy typehint with CursorResult
+  - Enables sqlalchemy>=1.4
+
 ## [1.0.3] - 2022-01-18
 ### Changed
   - Pin databricks plugin to thrift version

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.0.3"
+VERSION = "1.0.4"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/setup.py
+++ b/setup.py
@@ -35,13 +35,11 @@ REQUIREMENTS = [
     # Http
     "requests",
     # Sqlalchemy
-    # Pinned due to incompatibility with base client
-    "sqlalchemy<1.4",
+    "sqlalchemy>=1.4",
     # SFTP
     "pysftp>=0.2.0,<0.3",
     # Utils
-    # Pinned to due requiring sqlalchemy>=1.4
-    "pandas<1.4",
+    "pandas",
     "click",
     "pyyaml",
     "importlib_metadata",
@@ -90,7 +88,6 @@ setup_args = dict(
     ],
     cmdclass={"verify": VerifyVersionCommand},
 )
-
 
 if __name__ == "__main__":
 

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -7,7 +7,7 @@ import contextlib
 from typing import Container, Generator, Optional, Union
 
 import pandas as pd
-from sqlalchemy.engine import Connection, Engine, create_engine, result
+from sqlalchemy.engine import Connection, CursorResult, Engine, create_engine
 from sqlalchemy.engine import url as sqla_url
 from sqlalchemy.orm import session, sessionmaker
 from sqlalchemy.sql.schema import MetaData
@@ -119,7 +119,7 @@ class SQLAlchemyClient(base_client.BaseClient["SQLAlchemyClient"]):
     # Query methods:
 
     @decorators.check_conn
-    def query(self, sql_query: str, **kwargs) -> result.ResultProxy:
+    def query(self, sql_query: str, **kwargs) -> CursorResult:
         """Execute a read-only SQL query, and return results.
 
         This will not commit any changes to the database.


### PR DESCRIPTION
- Replace `result.ResultProxy` typehint with `CursorResult`
- From the `CursorResult` docstring:
```
    """A Result that is representing state from a DBAPI cursor.

    .. versionchanged:: 1.4  The :class:`.CursorResult` and
       :class:`.LegacyCursorResult`
       classes replace the previous :class:`.ResultProxy` interface.
       These classes are based on the :class:`.Result` calling API
       which provides an updated usage model and calling facade for
       SQLAlchemy Core and SQLAlchemy ORM.
```

https://docs.sqlalchemy.org/en/14/core/connections.html