### PR TITLE
Require importlib_metadata>3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ REQUIREMENTS = [
     "pandas<1.4",
     "click",
     "pyyaml",
-    "importlib_metadata",
+    "importlib_metadata>3.7.0",
 ]
 
 PLUGINS = {


### PR DESCRIPTION
`packages_distributions` was introduced in that version and it's being used in the repo