### PR TITLE
Add make_safe_write function

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2023-01-25
+### Added
+  - Add `tentaclio.streams.api.make_empty_safe` to modify the standard behavoir of creating 
+  empty files when no data is written into the stream.
+
 ## [1.0.8] - 2022-11-08
 ### Added
   - Make `tentaclio.fs.api.walk` visible outside of the module so it can be used from the root module

--- a/README.md
+++ b/README.md
@@ -192,6 +192,21 @@ with tentaclio.open("s3::/path/to/my/file", mode='w') as writer:
 ```
 `Readers`, `Writers` and their closeable versions can be used anywhere expecting a file-like object; pandas or pickle are examples of such functions.
 
+##### Notes on writing files for Spark, Presto, and similar downstream systems
+
+The default behaviour for the `open` context manager in python is to create an empty file when opening
+it in writable mode. This can be annoying if the process that creates the data within the `with` clause
+yields empty dataframes and nothing gets written. This will make Spark and Presto panic.
+
+To avoid this we can make the stream _empty safe_ so the empty buffer won't be flushed if no writes have been performed so no empty file will be created.
+
+
+```
+with tio.make_empty_safe(tio.open("s3://bucket/file.parquet", mode="wb")) as writer:
+    if not df.empty:
+        df.to_parquet(writer)
+```
+
 ### File system like operations to resources
 #### Listing resources
 Some URL schemes allow listing resources in a pythonnic way:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.0.8"
+VERSION = "1.0.9"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/protocols.py
+++ b/src/tentaclio/protocols.py
@@ -75,4 +75,4 @@ class WriterClosable(Writer, Closable, Protocol):
     ...
 
 
-AnyReaderWriter = Union[Reader, Writer]
+AnyReaderWriter = Union[ReaderClosable, WriterClosable]

--- a/src/tentaclio/streams/api.py
+++ b/src/tentaclio/streams/api.py
@@ -4,15 +4,20 @@ from typing import ContextManager
 from tentaclio import protocols
 from tentaclio.credentials import authenticate
 
-from .stream_registry import STREAM_HANDLER_REGISTRY
+from .base_stream import StreamerReader, StreamerWriter
+from .stream_registry import STREAM_HANDLER_REGISTRY, _WriterContextManager
 
 
 __all__ = ["open"]
 
 VALID_MODES = ("", "rb", "wb", "rt", "wt", "r", "w", "b", "t")
 
+AnyContextStreamerReaderWriter = Union[
+    ContextManager[StreamerReader], ContextManager[StreamerWriter]
+]
 
-def open(url: str, mode: str = None, **kwargs) -> ContextManager[protocols.AnyReaderWriter]:
+
+def open(url: str, mode: str = None, **kwargs) -> AnyContextStreamerReaderWriter:
     """Open a url and return a reader or writer depending on mode.
 
     Arguments:
@@ -46,13 +51,13 @@ def _assert_mode(mode: str):
         raise ValueError(f"Mode {mode} is not allowed. Valid modes are  {valid_modes}")
 
 
-def _open_writer(url: str, mode: str, **kwargs) -> ContextManager[protocols.Writer]:
+def _open_writer(url: str, mode: str, **kwargs) -> ContextManager[StreamerWriter]:
     """Open a url and return a writer."""
     authenticated = authenticate(url)
     return STREAM_HANDLER_REGISTRY.open_stream_writer(authenticated, mode, extras=kwargs)
 
 
-def _open_reader(url: str, mode: str, **kwargs) -> ContextManager[protocols.Reader]:
+def _open_reader(url: str, mode: str, **kwargs) -> ContextManager[StreamerReader]:
     """Open a url and return a reader."""
     authenticated = authenticate(url)
     return STREAM_HANDLER_REGISTRY.open_stream_reader(authenticated, mode, extras=kwargs)

--- a/src/tentaclio/streams/api.py
+++ b/src/tentaclio/streams/api.py
@@ -1,14 +1,14 @@
 """Main entry points to tentaclio-io."""
-from typing import ContextManager
+from typing import ContextManager, Union
 
 from tentaclio import protocols
 from tentaclio.credentials import authenticate
 
-from .base_stream import StreamerReader, StreamerWriter
+from .base_stream import DirtyStreamerWriter, StreamerReader, StreamerWriter
 from .stream_registry import STREAM_HANDLER_REGISTRY, _WriterContextManager
 
 
-__all__ = ["open"]
+__all__ = ["open", "make_empty_safe"]
 
 VALID_MODES = ("", "rb", "wb", "rt", "wt", "r", "w", "b", "t")
 
@@ -39,6 +39,13 @@ def open(url: str, mode: str = None, **kwargs) -> AnyContextStreamerReaderWriter
         return _open_writer(url=url, mode=mode, **kwargs)
     else:
         return _open_reader(url=url, mode=mode, **kwargs)
+
+
+def make_empty_safe(
+    context_writer: _WriterContextManager,
+) -> ContextManager[protocols.WriterClosable]:
+    """Make the writer to not flush the contents if nothing was written."""
+    return _WriterContextManager(DirtyStreamerWriter(context_writer.resource))
 
 
 # Helpers

--- a/src/tentaclio/streams/stream_client_handler.py
+++ b/src/tentaclio/streams/stream_client_handler.py
@@ -3,7 +3,6 @@ import io
 import logging
 from typing import Callable
 
-from tentaclio.protocols import ReaderClosable, WriterClosable
 from tentaclio.streams import base_stream
 from tentaclio.urls import URL
 
@@ -30,7 +29,7 @@ class StreamURLHandler:
         """Create a handler using  a stream client factory to instantiate the underlying client."""
         self.client_factory = client_factory
 
-    def open_reader_for(self, url: URL, mode: str, extras: dict) -> ReaderClosable:
+    def open_reader_for(self, url: URL, mode: str, extras: dict) -> base_stream.StreamerReader:
         """Open an stream client for reading."""
         client = self.client_factory(url, **extras)
 
@@ -40,7 +39,7 @@ class StreamURLHandler:
             client, encoding=extras.get("encoding", "utf-8")
         )
 
-    def open_writer_for(self, url: URL, mode: str, extras: dict) -> WriterClosable:
+    def open_writer_for(self, url: URL, mode: str, extras: dict) -> base_stream.StreamerWriter:
         """Open an stream client writing."""
         client = self.client_factory(url, **extras)
 

--- a/src/tentaclio/streams/stream_registry.py
+++ b/src/tentaclio/streams/stream_registry.py
@@ -1,50 +1,50 @@
 """Stream handler registry to open readers and writers to urls."""
 from typing import ClassVar, ContextManager, Optional, Protocol
 
-from tentaclio import protocols
 from tentaclio.registry import URLHandlerRegistry
+from tentaclio.streams import base_stream
 from tentaclio.urls import URL
 
 
 __all__ = ["STREAM_HANDLER_REGISTRY"]
 
 
-class _ReaderContextManager(ContextManager[protocols.Reader]):
+class _ReaderContextManager(ContextManager[base_stream.StreamerReader]):
     """Composed context manager for ReaderCloseables."""
 
-    def __init__(self, resource: protocols.ReaderClosable):
+    def __init__(self, resource: base_stream.StreamerReader):
         super(_ReaderContextManager, self).__init__()
         self.resource = resource
 
-    def __enter__(self) -> protocols.Reader:
+    def __enter__(self) -> base_stream.StreamerReader:
         return self.resource
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        return self.resource.close()
+        self.resource.close()
 
 
-class _WriterContextManager(ContextManager[protocols.Writer]):
+class _WriterContextManager(ContextManager[base_stream.StreamerWriter]):
     """Composed context manager for WriterCloseables."""
 
-    def __init__(self, resource: protocols.WriterClosable):
+    def __init__(self, resource: base_stream.StreamerWriter):
         super(_WriterContextManager, self).__init__()
         self.resource = resource
 
-    def __enter__(self) -> protocols.Writer:
+    def __enter__(self) -> base_stream.StreamerWriter:
         return self.resource
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        return self.resource.close()
+        self.resource.close()
 
 
 class StreamHandler(Protocol):
     """Protocol for handling stream resources."""
 
-    def open_reader_for(self, url: "URL", mode: str, extras: dict) -> protocols.ReaderClosable:
+    def open_reader_for(self, url: "URL", mode: str, extras: dict) -> base_stream.StreamerReader:
         """Open a reader for the given url."""
         ...
 
-    def open_writer_for(self, url: "URL", mode: str, extras: dict) -> protocols.WriterClosable:
+    def open_writer_for(self, url: "URL", mode: str, extras: dict) -> base_stream.StreamerWriter:
         """Open a writer for the given url."""
         ...
 
@@ -54,7 +54,7 @@ class StreamHandlerRegistry(URLHandlerRegistry[StreamHandler]):
 
     def open_stream_reader(
         self, url: URL, mode: str, extras: Optional[dict] = None
-    ) -> ContextManager[protocols.Reader]:
+    ) -> ContextManager[base_stream.StreamerReader]:
         """Open a reader for the stream located at this url."""
         extras = extras or {}
         reader = self.get_handler(url.scheme).open_reader_for(url, mode, extras)
@@ -62,7 +62,7 @@ class StreamHandlerRegistry(URLHandlerRegistry[StreamHandler]):
 
     def open_stream_writer(
         self, url: URL, mode: str, extras: Optional[dict] = None
-    ) -> ContextManager[protocols.Writer]:
+    ) -> ContextManager[base_stream.StreamerWriter]:
         """Open a writer for the stream located at this url."""
         extras = extras or {}
         writer = self.get_handler(url.scheme).open_writer_for(url, mode, extras)

--- a/tests/unit/streams/test_api.py
+++ b/tests/unit/streams/test_api.py
@@ -33,3 +33,10 @@ def test_reader_modes(mode, mocker):
     api.open("file://path/query", mode)
 
     mocked_open_reader.assert_called_once()
+
+
+def test_make_empty_safe(mocker):
+    writer = mocker.MagicMock()
+    wrapped = api.make_empty_safe(writer)
+    with wrapped as w:
+        assert not w.dirty

--- a/tests/unit/streams/test_base_stream.py
+++ b/tests/unit/streams/test_base_stream.py
@@ -23,6 +23,28 @@ class TestStreamerWriter:
         client.put.assert_called()
 
 
+class TestDirtyStreamerWriter:
+    def test_write_dirty(self, mocker):
+        client = mocker.MagicMock()
+        buff = io.StringIO()
+
+        writer = base_stream.DirtyStreamerWriter(base_stream.StreamerWriter(client, buff))
+        writer.write("hello")
+        assert "hello" == buff.getvalue()
+        writer.close()
+        client.put.assert_called()
+
+    def test_write_clean(self, mocker):
+        client = mocker.MagicMock()
+        buff = io.StringIO()
+
+        writer = base_stream.DirtyStreamerWriter(base_stream.StreamerWriter(client, buff))
+        writer.close()
+
+        assert buff.closed
+        client.put.assert_not_called()
+
+
 class TestStreamerReader:
     def test_read(self, mocker):
         client = mocker.MagicMock()


### PR DESCRIPTION
This allows to wrap a writer opened with tentaclio to not flush the buffer
   if no writes have been performed

   This makes the streamer incompatible with python `open` _but_ it means that
   now we can just use the stream when dealing with empty dataframes

   ``` 
with tio.make_empty_safe(tio.open("s3://blah/file.parquet", mode="wb"))
   as f:
      if not df.empty:
          df.to_parquet(f)
   ``` 
   will not create empty files