### PR TITLE
Improve credentials parsing errors

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2023-04-05
+### Changed 
+  - Credential files error reporting to help users identify the credentials issues
+
 ## [1.0.9] - 2023-01-25
 ### Added
   - Add `tentaclio.streams.api.make_empty_safe` to modify the standard behavoir of creating 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.0.9"
+VERSION = "1.1.0"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/credentials/__init__.py
+++ b/src/tentaclio/credentials/__init__.py
@@ -1,3 +1,4 @@
 """Credential management module."""
 from .api import *  # noqa
 from .injection import *  # noqa
+from .reader import TentaclioFileError  # noqa

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -16,6 +16,8 @@ TENTACLIO_SECRETS_FILE = "TENTACLIO__SECRETS_FILE"
 
 
 class TentaclioFileError(Exception):
+    """Tentaclio secrets file errors."""
+
     TENTACLIO_FILE = os.getenv(TENTACLIO_SECRETS_FILE, "<unknown file>")
     ERROR_TEMPLATE = """
 #########################################
@@ -30,6 +32,7 @@ Check https://github.com/octoenergy/tentaclio#credentials-file for more info abo
 """
 
     def __init__(self, message: str):
+        """Intialise a new TentaclioFileError."""
         message = self.ERROR_TEMPLATE.format(message=message, tentaclio_file=self.TENTACLIO_FILE)
         super().__init__(message)
 

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -3,7 +3,7 @@ import io
 import pytest
 
 from tentaclio import urls
-from tentaclio.credentials import injection, reader
+from tentaclio.credentials import TentaclioFileError, injection, reader
 
 
 @pytest.fixture
@@ -32,13 +32,13 @@ secrets:
 
 
 def test_bad_yaml():
-    with pytest.raises(Exception):
+    with pytest.raises(TentaclioFileError):
         data = io.StringIO("sadfsaf")
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_no_credentials_in_file(no_creds_yaml):
-    with pytest.raises(KeyError):
+    with pytest.raises(TentaclioFileError):
         data = io.StringIO(no_creds_yaml)
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 


### PR DESCRIPTION
Now will get the following errors as a `TentaclioFileError`: 
1. Not found: the file is not in the fs 
2. Missing `secrets:` element 
3. Yaml can't be   parsed: 
File name and error description/line included.
No context is shown in the logs as we would be logging passwords
```
   [...]
      creds = _load_creds_from_yaml(yaml_reader)
    File "/home/javi/src/tentaclio/src/tentaclio/credentials/reader.py", line
   66, in _load_creds_from_yaml
      raise TentaclioFileError(_process_mark_error(error)) 
   tentaclio.credentials.reader.TentaclioFileError:

   Your tentaclio secrets file is malformed:

   File: /home/javi/src/tentaclio/kk.yml

   expected alphabetic or numeric character, but found ' '
    in "<file>", line 1, column 2 while scanning an alias
    in "<file>", line 1, column 1
```