### PR TITLE
Fix update_query_string() returns new URL instance

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2023-04-20
+### Fix
+  - Issue where URL query parameters were not passed correctly to sqlalchemy for db connections.
+
 ## [1.2.0] - 2023-04-06
 ### Added
   - Add support for SQLAlchemy 2.0 by correctly handling `sqlalchemy.engine.url.URL`s, which are now immutable.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.2.0"
+VERSION = "1.2.1"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/sqla_client.py
+++ b/src/tentaclio/clients/sqla_client.py
@@ -97,7 +97,7 @@ class SQLAlchemyClient(base_client.BaseClient["SQLAlchemyClient"]):
             database=self.database,
         )
         if self.url.query_string:
-            parsed_url.update_query_string(self.url.query_string)
+            parsed_url = parsed_url.update_query_string(self.url.query_string)
         if self.engine is None:
             self.engine = create_engine(
                 parsed_url,


### PR DESCRIPTION
The `sqlalchemy.engine.url.URL.update_query_string()` method returns a new URL instance, and doesn't update in place:
https://github.com/sqlalchemy/sqlalchemy/blob/fc2bcead435a9bf0a2de8e9b15a1bd835f9d7fe4/lib/sqlalchemy/engine/url.py#L360

We therefore have to overwrite our variable `parsed_url`.

This fixes the bug whereby BigQuery URLs were getting passed without the query params: https://octoenergy.slack.com/archives/C01GPE6BZDJ/p1681975248180199