### PR TITLE
Add environmental variable interpolation support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2023-10-25
+### Added
+  - Add support for interpolating environment variables to tentaclio secrets file.
+
 ## [1.2.2] - 2023-10-18
 ### Added
   - Add support for connecting to SFTP via private key authentication. Replaces pysftp dependency with paramiko.

--- a/README.md
+++ b/README.md
@@ -302,6 +302,14 @@ And make it accessible to tentaclio by setting the environmental variable `TENTA
 Alternatively you can run `curl https://raw.githubusercontent.com/octoenergy/tentaclio/master/extras/init_tentaclio.sh` to create a secrets file in `~/.tentaclio.yml` and
 automatically configure your environment.
 
+Environment variables can be included in the credentials file by using `${ENV_VARIABLE}` as it follows:
+```
+secrets:
+    db: postgresql://${DB_USER}:${DB_PASS}@myhost.com/database
+```
+Tentaclio will search `DB_USER` and `DB_PASS` in the environment and will interpolate their values with the secrets file content.
+
+
 ## Quick note on protocols structural subtyping.
 
 In order to abstract concrete dependencies from the implementation of data related functions (or in any part of the system really) we use typed [protocols](https://mypy.readthedocs.io/en/latest/protocols.html#simple-user-defined-protocols). This allows a more flexible dependency injection than using subclassing or [more complex approches](http://code.activestate.com/recipes/413268/). This idea is heavily inspired by how this exact thing is done in [go](https://www.youtube.com/watch?v=ifBUfIb7kdo). Learn more about this principle in our [tech blog](https://tech.octopus.energy/news/2019/03/21/python-interfaces-a-la-go.html).

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.2.2"
+VERSION = "1.3.0"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -2,6 +2,7 @@
 import io
 import logging
 import os
+import re
 
 import yaml
 
@@ -13,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 SECRETS = "secrets"
 TENTACLIO_SECRETS_FILE = "TENTACLIO__SECRETS_FILE"
+ENV_VARIABLE_PATTERN = r"\${[a-zA-Z_]+[a-zA-Z0-9_]*}"
+NOT_VALID_ENV_VARIABLE_VALUES = "[${}]"
 
 
 class TentaclioFileError(Exception):
@@ -33,7 +36,9 @@ Check https://github.com/octoenergy/tentaclio#credentials-file for more info abo
 
     def __init__(self, message: str):
         """Intialise a new TentaclioFileError."""
-        message = self.ERROR_TEMPLATE.format(message=message, tentaclio_file=self.TENTACLIO_FILE)
+        message = self.ERROR_TEMPLATE.format(
+            message=message, tentaclio_file=self.TENTACLIO_FILE
+        )
         super().__init__(message)
 
 
@@ -85,6 +90,25 @@ def _load_from_file(
         raise TentaclioFileError("File not found") from e
 
 
+def replace_env_variables(url: str) -> str:
+    """Replace the environment variables inside the url by its value in the environment.
+
+    Environment variables match the following format: ${ENV_VARIABLE_NAME}
+    """
+    pattern = re.compile(ENV_VARIABLE_PATTERN)
+    env_variables = re.findall(pattern, url)
+    for env_variable in env_variables:
+        env_variable_name = re.sub(NOT_VALID_ENV_VARIABLE_VALUES, "", env_variable)
+        env_value = os.getenv(env_variable_name)
+        if not env_value:
+            raise EnvironmentError(
+                f"Error while reading variable '{env_variable_name}' from the environment. "
+                f"Check that the variable exists in your environment."
+            )
+        url = url.replace(env_variable, env_value)
+    return url
+
+
 def add_credentials_from_reader(
     injector: injection.CredentialsInjector, yaml_reader: protocols.Reader
 ) -> injection.CredentialsInjector:
@@ -99,6 +123,7 @@ def add_credentials_from_reader(
     creds = _load_creds_from_yaml(yaml_reader)
     for name, url in creds.items():
         logger.info(f"Adding secret: {name}")
+        url = replace_env_variables(url)
         try:
             injector.register_credentials(urls.URL(url))
         except Exception as e:

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -31,6 +31,24 @@ secrets:
 """
 
 
+@pytest.fixture
+def creds_yaml_env_variables():
+    return """
+secrets:
+    local_ftp: ftp://${USER}:${PASSWORD}@local.com
+    remote_db: postgresql://${USER_DB}:${PASSWORD_DB}@db.com/database
+"""
+
+
+@pytest.fixture
+def creds_yaml_bad_env_variables():
+    return """
+secrets:
+    local_ftp: ftp://${FAKE_USER}:${FAKE_PASSWORD}@local.com
+    remote_db: postgresql://${FAKE_USER_DB}:${FAKE_PASSWORD_DB}@db.com/database
+"""
+
+
 def test_bad_yaml():
     with pytest.raises(TentaclioFileError):
         data = io.StringIO("sadfsaf")
@@ -61,4 +79,30 @@ def test_credentials(url, expected, creds_yaml):
 def test_credentials_bad_url(creds_yaml_bad_url):
     data = io.StringIO(creds_yaml_bad_url)
     with pytest.raises(Exception):
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        ("ftp://local.com/file.txt", "ftp://user:password@local.com/file.txt"),
+        ("postgresql://db.com/database", "postgresql://user_db:password_db@db.com/database"),
+    ],
+)
+def test_credentials_env_variable(url, expected, creds_yaml_env_variables, monkeypatch):
+    monkeypatch.setenv('USER', 'user')
+    monkeypatch.setenv('USER_DB', 'user_db')
+    monkeypatch.setenv('PASSWORD', 'password')
+    monkeypatch.setenv('PASSWORD_DB', 'password_db')
+
+    data = io.StringIO(creds_yaml_env_variables)
+    injector = reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+    result = injector.inject(urls.URL(url))
+    assert result == urls.URL(expected)
+
+
+def test_credentials_bad_env_variable(creds_yaml_bad_env_variables):
+    data = io.StringIO(creds_yaml_bad_env_variables)
+    with pytest.raises(EnvironmentError):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)


### PR DESCRIPTION
### Description
Add environmental variable interpolation support.
If the tentaclio file looks like:
```
secrets:
  local_ftp: ftp://${USER}:${PASSWORD}@local.com
```
tentaclio will get the USER and PASSWORD values from the environment

### Link to ticket:
https://app.asana.com/0/1204998866317691/1204977339568190/f