### PR TITLE
Improve error message for secret parse error

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2024-01-04
+### Changed
+  - Error message when a Tentaclio secret cannot be passed to give more information to user.
+
 ## [1.3.0] - 2023-10-25
 ### Added
   - Add support for interpolating environment variables to tentaclio secrets file.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.3.0"
+VERSION = "1.3.1"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -36,9 +36,7 @@ Check https://github.com/octoenergy/tentaclio#credentials-file for more info abo
 
     def __init__(self, message: str):
         """Intialise a new TentaclioFileError."""
-        message = self.ERROR_TEMPLATE.format(
-            message=message, tentaclio_file=self.TENTACLIO_FILE
-        )
+        message = self.ERROR_TEMPLATE.format(message=message, tentaclio_file=self.TENTACLIO_FILE)
         super().__init__(message)
 
 

--- a/src/tentaclio/urls.py
+++ b/src/tentaclio/urls.py
@@ -50,7 +50,18 @@ class URL:
         if self._url is None:
             raise URLError("None url")
 
-        parsed_url = parse.urlparse(self._url)
+        try:
+            parsed_url = parse.urlparse(self._url)
+        except ValueError as e:
+            if str(e) == "Invalid IPv6 URL":
+                message = (
+                    "Please ensure the provided Tentaclio secret URL is in valid format."
+                    " If your password element contains special characters,"
+                    " please ensure it is URL encoded. You can do this using"
+                    "the Python urllib.parse.quote_plus() function."
+                )
+                raise ValueError("Invalid IPv6 URL : " + message)
+            raise e
 
         self._scheme = parsed_url.scheme
         self._username = parsed_url.username

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -90,10 +90,10 @@ def test_credentials_bad_url(creds_yaml_bad_url):
     ],
 )
 def test_credentials_env_variable(url, expected, creds_yaml_env_variables, monkeypatch):
-    monkeypatch.setenv('USER', 'user')
-    monkeypatch.setenv('USER_DB', 'user_db')
-    monkeypatch.setenv('PASSWORD', 'password')
-    monkeypatch.setenv('PASSWORD_DB', 'password_db')
+    monkeypatch.setenv("USER", "user")
+    monkeypatch.setenv("USER_DB", "user_db")
+    monkeypatch.setenv("PASSWORD", "password")
+    monkeypatch.setenv("PASSWORD_DB", "password_db")
 
     data = io.StringIO(creds_yaml_env_variables)
     injector = reader.add_credentials_from_reader(injection.CredentialsInjector(), data)


### PR DESCRIPTION
This PR improves the error messaging around the parsing of the tentaclio secrets. Parsing can fail if secret strings feature special characters. The current error suggests an incorrect IPV6 address however doesn't give an indication of the possible solution, this PR solves that.

Also some small linting fixes