### PR TITLE
Maintain optional input of private key path and private key password

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+
+## [1.3.2] - 2025-07-16
+### Fix
+  - Maintain optional input of private key path and private key password to SFTP client.
+
 ## [1.3.2] - 2025-07-12
 ### Added
   - Add support for use of private key path and private key password for SFTP using query parameters.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
-## [1.3.2] - 2025-07-16
+## [1.3.3] - 2025-07-16
 ### Fix
   - Maintain optional input of private key path and private key password to SFTP client.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.3.2"
+VERSION = "1.3.3"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 

--- a/src/tentaclio/clients/ftp_client.py
+++ b/src/tentaclio/clients/ftp_client.py
@@ -155,10 +155,10 @@ class SFTPClient(base_client.BaseClient["SFTPClient"]):
         self.username = self.url.username or ""
         self.password = self.url.password or ""
         self.port = self.url.port or 22
-        self.private_key_path = private_key_path or self.url.query.get(
-            "private_key_path") if self.url.query else None
-        self.private_key_password = private_key_password or self.url.query.get(
-            "private_key_password") if self.url.query else None
+        self.private_key_path = private_key_path or (self.url.query.get(
+            "private_key_path") if self.url.query else None)
+        self.private_key_password = private_key_password or (self.url.query.get(
+            "private_key_password") if self.url.query else None)
 
     def _get_private_key(self) -> PKey:
         if not self.private_key_path:


### PR DESCRIPTION
- Fix for 1.3.2 - to enable optional input of private key path and private key password directly to the SFTP client