### PR TITLE
Update ci config to use PyPI API token for publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,10 +9,9 @@ version: 2.1
 executors:
   standard:
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           PIPENV_VENV_IN_PROJECT: true
-    working_directory: "~/lib"
 
 # -----------------
 # Reusable commands
@@ -77,10 +76,9 @@ jobs:
           command: make unit
 
   release:
-    working_directory: ~/lib
 
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
 
     steps:
       - checkout_source
@@ -101,8 +99,8 @@ jobs:
           name: init .pypirc
           command: |
             echo -e "[pypi]" >> ~/.pypirc
-            echo -e "username = octoenergy" >> ~/.pypirc
-            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+            echo -e "username = __token__" >> ~/.pypirc
+            echo -e "password = $PYPI_API_TOKEN" >> ~/.pypirc
 
       - run:
           name: create release
@@ -111,10 +109,9 @@ jobs:
 
 
   functional-ftp:
-    working_directory: ~/lib
 
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TENTACLIO__CONN__FTP_TEST: ftp://octopus:tentacle@localhost
 
@@ -136,10 +133,9 @@ jobs:
 
 
   functional-sftp:
-    working_directory: ~/lib
 
     docker:
-      - image: circleci/python:3.9
+      - image: cimg/python:3.9
         environment:
           TENTACLIO__CONN__SFTP_TEST: sftp://octopus:tentacle@localhost:22
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 2025-07-21
+### Added
+  - Update CircleCI config to use latest convenience image for Python 3.9. and use an API token for publishing to PyPI.
 
 ## [1.3.2] - 2025-07-12
 ### Added

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.3.2"
+VERSION = "1.3.3"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
PyPI no longer accepts username and password for authentication.
This PR updates the auth to use an API token saved in the CIrcleCI context.
Also updates the CI images to convenience images.