### PR TITLE
Pin paramiko version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.5] - 2025-08-04
+### Fix
+  - Pin Paramiko dependency version to <4.0.0 to avoid DSSKey error (support dropped in newest version).
+
 ## [1.3.4] - 2025-07-21
 ### Added
   - Update CircleCI config to use latest convenience image for Python 3.9. and use an API token for publishing to PyPI.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.3.4"
+VERSION = "1.3.5"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 
@@ -37,7 +37,7 @@ REQUIREMENTS = [
     # Sqlalchemy
     "sqlalchemy>=1.4",
     # SFTP
-    "paramiko",
+    "paramiko<4.0.0",
     # Utils
     "pandas",
     "click",


### PR DESCRIPTION
Pins the paramiko dependency version to `<4.0.0` to avoid DSSKey error. Support for DSSKey was [dropped](https://www.paramiko.org/changelog.html) in `v4.0.0`.

Slack [thread](https://krakentech.slack.com/archives/C0853EN8NCA/p1754270831054229)