### PR TITLE
fix: not identifying shell type exits terminal

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.7] - 2025-09-15
+### Fix
+  - Fix and improve shell detection in extras/init_tentaclio.sh.
+
 ## [1.3.6] - 2025-08-04
 ### Fix
   - Re-lock pipfile to fix release process.

--- a/extras/init_tentaclio.sh
+++ b/extras/init_tentaclio.sh
@@ -34,7 +34,7 @@ case "$shell" in
         profile="$HOME/.config/fish/config.fish"
         ;;
     * )
-        echo "🤔 I don't know how to cofigure your $shell, please add"
+        echo "🤔 I don't know how to configure your $shell, please add"
         echo ""
         echo "\texport TENTACLIO__SECRETS_FILE=${HOME}/.tentaclio.yml"
         echo ""
@@ -46,7 +46,7 @@ esac
 if [[ -z $(grep TENTACLIO__SECRETS_FILE $profile) ]]; then
     echo "export TENTACLIO__SECRETS_FILE=$HOME/.tentaclio.yml # tentaclio secrets file" >> $profile
 else
-    echo "🙅 Envrionmental variable already in profile file, doing nothing."
+    echo "🙅 Environmental variable already in profile file, doing nothing."
 fi
 
 echo "🕵️  Now you can edit ~/.tentaclio.yml to add your secrets"

--- a/extras/init_tentaclio.sh
+++ b/extras/init_tentaclio.sh
@@ -21,14 +21,14 @@ if [ -z "$shell" ]; then
         # Valid shell detected, keep it
         ;;
     *)
-        # Not a valid shell, fall back to $SHELL
+        # Not a valid shell, fall back to $SHELL (default user shell)
         shell="$(basename "$SHELL")"
+        echo "🤔 Could not detect shell from PID, using default user shell ${SHELL}. Check if you are using that shell."
         ;;
   esac
 fi
 
-echo $shell
-return
+echo "🐚 Detected shell: $shell"
 
 echo "📃 Adding TENTACLIO__SECRETS_FILE to profile file."
 case "$shell" in

--- a/extras/init_tentaclio.sh
+++ b/extras/init_tentaclio.sh
@@ -13,11 +13,22 @@ fi
 
 # Add secrets file to profile file.
 if [ -z "$shell" ]; then
-  shell="$(ps c -p "$PPID" -o 'ucomm=' 2>/dev/null || true)"
+  shell="$(ps c -p "$$" -o 'ucomm=' 2>/dev/null || true)"
   shell="${shell##-}"
   shell="${shell%% *}"
-  shell="$(basename "${shell:-$SHELL}")"
+  case "$shell" in
+    bash|zsh|ksh|fish)
+        # Valid shell detected, keep it
+        ;;
+    *)
+        # Not a valid shell, fall back to $SHELL
+        shell="$(basename "$SHELL")"
+        ;;
+  esac
 fi
+
+echo $shell
+return
 
 echo "📃 Adding TENTACLIO__SECRETS_FILE to profile file."
 case "$shell" in

--- a/extras/init_tentaclio.sh
+++ b/extras/init_tentaclio.sh
@@ -36,10 +36,10 @@ case "$shell" in
     * )
         echo "🤔 I don't know how to cofigure your $shell, please add"
         echo ""
-        echo "\texport TENTACLIO__SECRETS_FILE=${HOME}/.tentaclio.yml" 
+        echo "\texport TENTACLIO__SECRETS_FILE=${HOME}/.tentaclio.yml"
         echo ""
         echo "to your profile file."
-        exit
+        return
         ;;
 esac
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from setuptools import find_packages, setup
 from setuptools.command.install import install
 
 
-VERSION = "1.3.6"
+VERSION = "1.3.7"
 
 REPO_ROOT = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
Minor inconvenience:

- previously when this setup script wasn't able to identify the shell type it would exit the script and terminal window meaning the user cannot see any script output
- changing the exit command to a return prevents the terminal termination and allows the user to see the script output
- also improved shell detection