### PR TITLE
Add type overloads to open() for mode-based narrowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,11 @@ sections = ["STDLIB", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]
 exclude = ["logs", ".*/*.py", "*.egg-info"]
 max-line-length = 99
 max-complexity = 10
-ignore = ["F405", "W391", "W503"]
+ignore = ["F405", "W391", "W503", "E704"]
+per-file-ignores = ["src/tentaclio/streams/api.py:E302"]
+
+[tool.pydocstyle]
+ignore_decorators = "overload"
 
 [tool.black]
 line-length = 99

--- a/src/tentaclio/streams/api.py
+++ b/src/tentaclio/streams/api.py
@@ -1,5 +1,5 @@
 """Main entry points to tentaclio-io."""
-from typing import ContextManager, Optional, Union
+from typing import ContextManager, Literal, Optional, Union, overload
 
 from tentaclio import protocols
 from tentaclio.credentials import authenticate
@@ -15,6 +15,16 @@ VALID_MODES = ("", "rb", "wb", "rt", "wt", "r", "w", "b", "t")
 AnyContextStreamerReaderWriter = Union[
     ContextManager[StreamerReader], ContextManager[StreamerWriter]
 ]
+
+
+# Overloads narrow the return type based on mode, so type checkers
+# know that mode="w" yields a writer and mode="r" yields a reader.
+@overload
+def open(url: str, mode: Literal["w", "wt", "wb"], **kwargs) -> ContextManager[StreamerWriter]: ...
+@overload
+def open(url: str, mode: Literal["r", "rt", "rb", "b", "t", ""] = ..., **kwargs) -> ContextManager[StreamerReader]: ...
+@overload  # fallback for dynamic mode values
+def open(url: str, mode: Optional[str] = ..., **kwargs) -> AnyContextStreamerReaderWriter: ...
 
 
 def open(url: str, mode: Optional[str] = None, **kwargs) -> AnyContextStreamerReaderWriter:

--- a/src/tentaclio/streams/api.py
+++ b/src/tentaclio/streams/api.py
@@ -1,4 +1,5 @@
 """Main entry points to tentaclio-io."""
+
 from typing import ContextManager, Literal, Optional, Union, overload
 
 from tentaclio import protocols
@@ -22,7 +23,9 @@ AnyContextStreamerReaderWriter = Union[
 @overload
 def open(url: str, mode: Literal["w", "wt", "wb"], **kwargs) -> ContextManager[StreamerWriter]: ...
 @overload
-def open(url: str, mode: Literal["r", "rt", "rb", "b", "t", ""] = ..., **kwargs) -> ContextManager[StreamerReader]: ...
+def open(
+    url: str, mode: Literal["r", "rt", "rb", "b", "t", ""] = ..., **kwargs
+) -> ContextManager[StreamerReader]: ...
 @overload  # fallback for dynamic mode values
 def open(url: str, mode: Optional[str] = ..., **kwargs) -> AnyContextStreamerReaderWriter: ...
 


### PR DESCRIPTION
## Summary
- Adds `@overload` signatures to `tentaclio.open()` so type checkers can narrow the return type based on the `mode` argument
- `mode="w"/"wt"/"wb"` → `ContextManager[StreamerWriter]`
- `mode="r"/"rt"/"rb"/"b"/"t"/""` → `ContextManager[StreamerReader]`
- Fallback overload for dynamic `mode` values preserves the existing union return type

## Test plan
- [ ] Verify `tio.open(url, mode="w")` narrows to `StreamerWriter` in mypy/pyright/ty
- [ ] Verify `tio.open(url, mode="r")` narrows to `StreamerReader`
- [ ] Verify `tio.open(url, mode=some_variable)` still returns the union type

🤖 Generated with [Claude Code](https://claude.com/claude-code)