### PR TITLE
Expand ~ in the credentials file path

### DIFF
--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -81,6 +81,9 @@ def _load_creds_from_yaml(yaml_reader: protocols.Reader) -> dict:
 def _load_from_file(
     injector: injection.CredentialsInjector, path: str
 ) -> injection.CredentialsInjector:
+    # Expand a leading ~ so a path like ~/secrets.yaml resolves to the user's
+    # home directory rather than a literal "~" entry in the working directory.
+    path = os.path.expanduser(path)
     try:
         with open(path, "r") as f:
             return add_credentials_from_reader(injector, f)

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -106,3 +106,15 @@ def test_credentials_bad_env_variable(creds_yaml_bad_env_variables):
     data = io.StringIO(creds_yaml_bad_env_variables)
     with pytest.raises(EnvironmentError):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+def test_load_from_file_expands_user_path(tmp_path, monkeypatch, creds_yaml):
+    """A leading ~ in the secrets path resolves to the user's home."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    (tmp_path / "secrets.yaml").write_text(creds_yaml)
+
+    injector = reader._load_from_file(injection.CredentialsInjector(), "~/secrets.yaml")
+
+    result = injector.inject(urls.URL("ftp://local.com/file.txt"))
+    assert result == urls.URL("ftp://user:password@local.com/file.txt")


### PR DESCRIPTION
Closes #97.

`_load_from_file` passed the credentials path straight to `open()`, so a leading `~` was never expanded. A path like `TENTACLIO__SECRETS_FILE=~/secrets.yaml` was therefore treated as a literal `~/secrets.yaml` in the working directory and raised `TentaclioFileError`, even though the file existed in the user's home.

Expanding with `os.path.expanduser` before opening fixes it, matching how a shell would resolve the path. Environment-variable interpolation was already handled; this adds the home-directory case.

Added a unit test that points a `~/secrets.yaml` path at a temporary home and asserts the credentials load.
