### PR TITLE
Error handling for more malformed yaml secrets file cases

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,9 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for anyone building docs locally or on Read the Docs with an unpinned resolver.
 ### Added
   - Add `Programming Language :: Python :: 3.13` classifier.
-  - Add more validation for tentaclio secrets yaml files, including checks that the top level of
-    the yaml file contains key-value pairs, the `secrets:` block is not empty, the `secrets:` block
-    and subsequent entries are correctly indented, and the `secrets:` block contains key-values
+  - Add more validation for tentaclio secrets YAML files, including checks that the top level of
+    the YAML file contains key-value pairs, the `secrets:` block is not empty, the `secrets:` block
+    and subsequent entries are correctly indented, and the `secrets:` block contains key-value
     pairs. If any of the validation steps fail, `TentaclioFileError`s with helpful error messages
     are raised.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -53,6 +53,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     for anyone building docs locally or on Read the Docs with an unpinned resolver.
 ### Added
   - Add `Programming Language :: Python :: 3.13` classifier.
+  - Add more validation for tentaclio secrets yaml files, including checks that the top level of
+    the yaml file contains key-value pairs, the `secrets:` block is not empty, the `secrets:` block
+    and subsequent entries are correctly indented, and the `secrets:` block contains key-values
+    pairs. If any of the validation steps fail, `TentaclioFileError`s with helpful error messages
+    are raised.
 
 ## [1.4.1] - 2026-01-12
 ### Fix

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ tentaclio.remove("s3://my-bucket/octopus/the-9th-tentacle.txt")
 ```python
 import tentaclio
 
-for entry in tentaclio.listdir("s3://mybucket/path/to/dir"):
+for entry in tentaclio.listdir("s3://my-bucket/path/to/dir"):
     print("Entry", entry)
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ tentaclio.remove("s3://my-bucket/octopus/the-9th-tentacle.txt")
 ```python
 import tentaclio
 
-for entry in tentaclio.listdir("s3:://mybucket/path/to/dir"):
+for entry in tentaclio.listdir("s3://mybucket/path/to/dir"):
     print("Entry", entry)
 ```
 
@@ -193,7 +193,7 @@ with tentaclio.open("/path/to/my/file") as reader:
 
 [...]
 
-with tentaclio.open("s3::/path/to/my/file", mode='w') as writer:
+with tentaclio.open("s3:/path/to/my/file", mode='w') as writer:
     df.to_parquet(writer)
 ```
 `Readers`, `Writers` and their closeable versions can be used anywhere expecting a file-like object; pandas or pickle are examples of such functions.
@@ -219,7 +219,7 @@ Some URL schemes allow listing resources in a pythonic way:
 ```python
 import tentaclio
 
-for entry in tentaclio.listdir("s3:://mybucket/path/to/dir"):
+for entry in tentaclio.listdir("s3://mybucket/path/to/dir"):
     print("Entry", entry)
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Python library that simplifies:
 Main considerations in the design:
 * Easy to use: all streams are open via `tentaclio.open`, all database connections through `tentaclio.db`.
 * URLs are the basic resource locator and db connection string.
-* Automagic authentication for protected resources.
+* Automatic authentication for protected resources.
 * Extensible: you can add your own handlers for other schemes.
 * Pandas interaction.
 
@@ -215,7 +215,7 @@ with tio.make_empty_safe(tio.open("s3://bucket/file.parquet", mode="wb")) as wri
 
 ### File system like operations to resources
 #### Listing resources
-Some URL schemes allow listing resources in a pythonnic way:
+Some URL schemes allow listing resources in a pythonic way:
 ```python
 import tentaclio
 
@@ -223,7 +223,7 @@ for entry in tentaclio.listdir("s3:://mybucket/path/to/dir"):
     print("Entry", entry)
 ```
 
-Whereas `listdir` might be convinient we also offer `scandir`, which returns a list of [DirEntry](https://github.com/octopus-energy/tentaclio/blob/ddbc28615de4b99106b956556db74a20e4761afe/src/tentaclio/fs/scanner.py#L13)s, and, `walk`. All functions follow as closely as possible their standard library definitions.
+Whereas `listdir` might be convenient we also offer `scandir`, which returns a list of [DirEntry](https://github.com/octopus-energy/tentaclio/blob/ddbc28615de4b99106b956556db74a20e4761afe/src/tentaclio/fs/scanner.py#L13)s, and, `walk`. All functions follow as closely as possible their standard library definitions.
 
 
 ### Database access
@@ -296,7 +296,7 @@ Different components of the URL are set differently:
 - Username, password and hostname will be set from the stored credentials.
 - Port will be set from the stored credentials if it exists, otherwise from the URL.
 - Query will be set from the URL if it exists, otherwise from the stored credentials (so it can be
-  overriden)
+  overridden)
 
 #### Credentials file
 
@@ -329,4 +329,4 @@ Tentaclio will search `DB_USER` and `DB_PASS` in the environment and will interp
 
 ## Quick note on protocols structural subtyping.
 
-In order to abstract concrete dependencies from the implementation of data related functions (or in any part of the system really) we use typed [protocols](https://mypy.readthedocs.io/en/latest/protocols.html#simple-user-defined-protocols). This allows a more flexible dependency injection than using subclassing or [more complex approches](http://code.activestate.com/recipes/413268/). This idea is heavily inspired by how this exact thing is done in [go](https://www.youtube.com/watch?v=ifBUfIb7kdo). Learn more about this principle in our [tech blog](https://tech.octopus.energy/news/2019/03/21/python-interfaces-a-la-go.html).
+In order to abstract concrete dependencies from the implementation of data related functions (or in any part of the system really) we use typed [protocols](https://mypy.readthedocs.io/en/latest/protocols.html#simple-user-defined-protocols). This allows a more flexible dependency injection than using subclassing or [more complex approaches](http://code.activestate.com/recipes/413268/). This idea is heavily inspired by how this exact thing is done in [go](https://www.youtube.com/watch?v=ifBUfIb7kdo). Learn more about this principle in our [tech blog](https://tech.octopus.energy/news/2019/03/21/python-interfaces-a-la-go.html).

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import os
 
 import tentaclio
 
-print("env ftp credentials", os.getenv("TENTACLIO__CONN__OCTOPUS_FTP"))
+print("env ftp credentials", os.getenv("TENTACLIO__CONN__OCTOPUS_ENERGY_FTP"))
 # This prints `sftp://constantine:tentacl3@sftp.octopus.energy/`
 
 # Credentials get automatically injected.

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ with tentaclio.open("/path/to/my/file") as reader:
 
 [...]
 
-with tentaclio.open("s3:/path/to/my/file", mode='w') as writer:
+with tentaclio.open("s3://my-bucket/path/to/my/file", mode='w') as writer:
     df.to_parquet(writer)
 ```
 `Readers`, `Writers` and their closeable versions can be used anywhere expecting a file-like object; pandas or pickle are examples of such functions.
@@ -208,7 +208,7 @@ To avoid this we can make the stream _empty safe_ so the empty buffer won't be f
 
 
 ```
-with tio.make_empty_safe(tio.open("s3://bucket/file.parquet", mode="wb")) as writer:
+with tio.make_empty_safe(tio.open("s3://my-bucket/file.parquet", mode="wb")) as writer:
     if not df.empty:
         df.to_parquet(writer)
 ```
@@ -219,7 +219,7 @@ Some URL schemes allow listing resources in a pythonic way:
 ```python
 import tentaclio
 
-for entry in tentaclio.listdir("s3://mybucket/path/to/dir"):
+for entry in tentaclio.listdir("s3://my-bucket/path/to/dir"):
     print("Entry", entry)
 ```
 

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -71,11 +71,37 @@ def _load_creds_from_yaml(yaml_reader: protocols.Reader) -> dict:
     except yaml.MarkedYAMLError as error:
         raise TentaclioFileError(_process_mark_error(error))
 
+    if not isinstance(loaded_data, dict):
+        raise TentaclioFileError(
+            "The yaml data is not a mapping of key-value pairs like:\n"
+            "    secrets:\n"
+            "        my_creds_name: http://user:password@google.com/path\n"
+            "        my_db: postgres://user_db:password@octopus.energy/database\n"
+            "I.e. the data type returned by `yaml.safe_load()` is not a `dict` python dtype."
+        )
     if SECRETS not in loaded_data:
         raise TentaclioFileError(
             "No secrets in yaml data. Make sure the file has a `secrets:` element"
         )
-    return loaded_data[SECRETS]
+
+    secrets = loaded_data[SECRETS]
+
+    if secrets is None:
+        raise TentaclioFileError(
+            "No entries found within the `secrets:` block of the yaml data.\n"
+            "Are the entries indented correctly or is the `secrets:` block empty?"
+        )
+    if not isinstance(secrets, dict):
+        raise TentaclioFileError(
+            "The `secrets:` block of the yaml data is not a mapping of key-value pairs like:\n"
+            "    secrets:\n"
+            "        my_creds_name: http://user:password@google.com/path\n"
+            "        my_db: postgres://user_db:password@octopus.energy/database\n"
+            "I.e. the data type returned by `yaml.safe_load()` for the `secrets:` block is not a "
+            "`dict` python dtype."
+        )
+
+    return secrets
 
 
 def _load_from_file(

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -80,7 +80,7 @@ def _load_creds_from_yaml(yaml_reader: protocols.Reader) -> dict:
             "The YAML secrets file must be a mapping of key-value pairs like:\n"
             f"    {SECRETS}:\n"
             "        my_creds_name: http://user:password@google.com/path\n"
-            "        my_db: postgres://user_db:password@octopus.energy/database\n"
+            "        my_db: postgresql://user_db:password@octopus.energy/database\n"
             "The value returned by `yaml.safe_load()` was not a Python `dict`."
         )
     if SECRETS not in loaded_data:
@@ -102,7 +102,7 @@ def _load_creds_from_yaml(yaml_reader: protocols.Reader) -> dict:
             "pairs like:\n"
             f"    {SECRETS}:\n"
             "        my_creds_name: http://user:password@google.com/path\n"
-            "        my_db: postgres://user_db:password@octopus.energy/database\n"
+            "        my_db: postgresql://user_db:password@octopus.energy/database\n"
             f"The value returned by `yaml.safe_load()` for the `{SECRETS}:` block was not a "
             "Python `dict`."
         )
@@ -147,7 +147,7 @@ def add_credentials_from_reader(
     The file has the following format:
         secrets:
             my_creds_name: http://user:password@google.com/path
-            my_db: postgres://user_db:password@octopus.energy/database
+            my_db: postgresql://user_db:password@octopus.energy/database
 
     """
     creds = _load_creds_from_yaml(yaml_reader)

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -71,34 +71,40 @@ def _load_creds_from_yaml(yaml_reader: protocols.Reader) -> dict:
     except yaml.MarkedYAMLError as error:
         raise TentaclioFileError(_process_mark_error(error))
 
+    if loaded_data is None:
+        raise TentaclioFileError(
+            f"The YAML secrets file is empty. It must contain a top-level `{SECRETS}:` key."
+        )
     if not isinstance(loaded_data, dict):
         raise TentaclioFileError(
-            "The yaml data is not a mapping of key-value pairs like:\n"
-            "    secrets:\n"
+            "The YAML secrets file must be a mapping of key-value pairs like:\n"
+            f"    {SECRETS}:\n"
             "        my_creds_name: http://user:password@google.com/path\n"
             "        my_db: postgres://user_db:password@octopus.energy/database\n"
-            "I.e. the data type returned by `yaml.safe_load()` is not a `dict` python dtype."
+            "The value returned by `yaml.safe_load()` was not a Python `dict`."
         )
     if SECRETS not in loaded_data:
         raise TentaclioFileError(
-            "No secrets in yaml data. Make sure the file has a `secrets:` element"
+            f"No `{SECRETS}:` key found in YAML secrets file. Make sure the file has a "
+            f"`{SECRETS}:` element."
         )
 
     secrets = loaded_data[SECRETS]
 
     if secrets is None:
         raise TentaclioFileError(
-            "No entries found within the `secrets:` block of the yaml data.\n"
-            "Are the entries indented correctly or is the `secrets:` block empty?"
+            f"No entries found within the `{SECRETS}:` block of the YAML secrets file.\n"
+            f"Are the entries indented correctly or is the `{SECRETS}:` block empty?"
         )
     if not isinstance(secrets, dict):
         raise TentaclioFileError(
-            "The `secrets:` block of the yaml data is not a mapping of key-value pairs like:\n"
-            "    secrets:\n"
+            f"The `{SECRETS}:` block of the YAML secrets file must be a mapping of key-value "
+            "pairs like:\n"
+            f"    {SECRETS}:\n"
             "        my_creds_name: http://user:password@google.com/path\n"
             "        my_db: postgres://user_db:password@octopus.energy/database\n"
-            "I.e. the data type returned by `yaml.safe_load()` for the `secrets:` block is not a "
-            "`dict` python dtype."
+            f"The value returned by `yaml.safe_load()` for the `{SECRETS}:` block was not a "
+            "Python `dict`."
         )
 
     return secrets

--- a/src/tentaclio/credentials/reader.py
+++ b/src/tentaclio/credentials/reader.py
@@ -112,10 +112,10 @@ def add_credentials_from_reader(
 ) -> injection.CredentialsInjector:
     """Read the credentials from a yml.
 
-    The file has the follwing format:
+    The file has the following format:
         secrets:
             my_creds_name: http://user:password@google.com/path
-            my_db: postgres://user_db:password@octoenergy.com/databasek
+            my_db: postgres://user_db:password@octopus.energy/database
 
     """
     creds = _load_creds_from_yaml(yaml_reader)

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -87,10 +87,7 @@ secrets:
 
 
 def test_bad_yaml():
-    with pytest.raises(
-        TentaclioFileError,
-        match="expected '<document start>', but found '<block mapping start>'",
-    ):
+    with pytest.raises(TentaclioFileError, match="Your tentaclio secrets file is malformed"):
         data = io.StringIO("  a: b\nc: d")
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -20,9 +20,9 @@ def creds_yaml_not_key_value_mapping():
 
 
 @pytest.fixture
-def no_creds_yaml():
+def no_secrets_block_yaml():
     return """
-example: []
+example: {}
 """
 
 
@@ -87,44 +87,56 @@ secrets:
 
 
 def test_bad_yaml():
-    with pytest.raises(TentaclioFileError):
-        data = io.StringIO("sadfsaf")
+    with pytest.raises(
+        TentaclioFileError,
+        match="expected '<document start>', but found '<block mapping start>'",
+    ):
+        data = io.StringIO("  a: b\nc: d")
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_empty_credentials_file(empty_creds_yaml):
-    with pytest.raises(TentaclioFileError):
+    with pytest.raises(TentaclioFileError, match="The YAML secrets file is empty"):
         data = io.StringIO(empty_creds_yaml)
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_credentials_file_not_key_value_mapping(creds_yaml_not_key_value_mapping):
-    with pytest.raises(TentaclioFileError):
+    with pytest.raises(
+        TentaclioFileError,
+        match="The YAML secrets file must be a mapping of key-value pairs",
+    ):
         data = io.StringIO(creds_yaml_not_key_value_mapping)
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
-def test_no_credentials_in_file(no_creds_yaml):
-    with pytest.raises(TentaclioFileError):
-        data = io.StringIO(no_creds_yaml)
+def test_credentials_no_secrets_block(no_secrets_block_yaml):
+    with pytest.raises(TentaclioFileError, match="No `secrets:` key found in YAML secrets file"):
+        data = io.StringIO(no_secrets_block_yaml)
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_credentials_empty_secrets(creds_yaml_empty_secrets):
     data = io.StringIO(creds_yaml_empty_secrets)
-    with pytest.raises(TentaclioFileError):
+    with pytest.raises(TentaclioFileError, match="No entries found within the `secrets:` block"):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_credentials_secrets_bad_indentation(creds_yaml_secrets_bad_indentation):
     data = io.StringIO(creds_yaml_secrets_bad_indentation)
-    with pytest.raises(TentaclioFileError):
+    with pytest.raises(TentaclioFileError, match="Are the entries indented correctly"):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
 def test_credentials_secrets_not_key_value_mapping(creds_yaml_secrets_not_key_value_mapping):
     data = io.StringIO(creds_yaml_secrets_not_key_value_mapping)
-    with pytest.raises(TentaclioFileError):
+    with pytest.raises(
+        TentaclioFileError,
+        match=(
+            r"The value returned by `yaml.safe_load\(\)` for the `secrets:` block was not a "
+            r"Python `dict`"
+        ),
+    ):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 

--- a/tests/unit/credentials/test_reader.py
+++ b/tests/unit/credentials/test_reader.py
@@ -7,6 +7,19 @@ from tentaclio.credentials import TentaclioFileError, injection, reader
 
 
 @pytest.fixture
+def empty_creds_yaml():
+    return ""
+
+
+@pytest.fixture
+def creds_yaml_not_key_value_mapping():
+    return """
+- 1
+- 2
+"""
+
+
+@pytest.fixture
 def no_creds_yaml():
     return """
 example: []
@@ -19,6 +32,30 @@ def creds_yaml():
 secrets:
     local_ftp: ftp://user:password@local.com
     remote_db: postgresql://user_db:password_db@db.com/database
+"""
+
+
+@pytest.fixture
+def creds_yaml_empty_secrets():
+    return """
+secrets:
+"""
+
+
+@pytest.fixture
+def creds_yaml_secrets_bad_indentation():
+    return """
+secrets:
+local_ftp: ftp://user:password@local.com
+"""
+
+
+@pytest.fixture
+def creds_yaml_secrets_not_key_value_mapping():
+    return """
+secrets:
+    - 1
+    - 2
 """
 
 
@@ -55,9 +92,39 @@ def test_bad_yaml():
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 
+def test_empty_credentials_file(empty_creds_yaml):
+    with pytest.raises(TentaclioFileError):
+        data = io.StringIO(empty_creds_yaml)
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+def test_credentials_file_not_key_value_mapping(creds_yaml_not_key_value_mapping):
+    with pytest.raises(TentaclioFileError):
+        data = io.StringIO(creds_yaml_not_key_value_mapping)
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
 def test_no_credentials_in_file(no_creds_yaml):
     with pytest.raises(TentaclioFileError):
         data = io.StringIO(no_creds_yaml)
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+def test_credentials_empty_secrets(creds_yaml_empty_secrets):
+    data = io.StringIO(creds_yaml_empty_secrets)
+    with pytest.raises(TentaclioFileError):
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+def test_credentials_secrets_bad_indentation(creds_yaml_secrets_bad_indentation):
+    data = io.StringIO(creds_yaml_secrets_bad_indentation)
+    with pytest.raises(TentaclioFileError):
+        reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
+
+
+def test_credentials_secrets_not_key_value_mapping(creds_yaml_secrets_not_key_value_mapping):
+    data = io.StringIO(creds_yaml_secrets_not_key_value_mapping)
+    with pytest.raises(TentaclioFileError):
         reader.add_credentials_from_reader(injection.CredentialsInjector(), data)
 
 


### PR DESCRIPTION
Add tentaclio secrets yaml file error handling for cases where:
i) the `secrets:` block is empty
ii) the entries after the `secrets:` block are not indented correctly
iii) the entries after the `secrets:` block are not key-value pairs (i.e. dict not returned for that block)
iv) the top level yaml structure is not a key-value mapping, (i.e. dict not returned for the top level block)

Also while we are here:
- Update all `octoenergy` GitHub org links to the new `octopus-energy` org
- Use `octopus.energy` instead of `octoenergy.com` as the domain in examples (former offers better brand awareness)
- Correct some small typos and mistakes